### PR TITLE
Remove oxen tap from installation instructions

### DIFF
--- a/getting-started/install.mdx
+++ b/getting-started/install.mdx
@@ -12,10 +12,6 @@ You can find the source code for the client [here](https://github.com/Oxen-AI/Ox
 ### Mac
 
 ```bash
-brew tap Oxen-AI/oxen
-```
-
-```bash
 brew install oxen
 ```
 

--- a/getting-started/versioning.mdx
+++ b/getting-started/versioning.mdx
@@ -37,7 +37,6 @@ Oxen makes versioning your datasets as easy as versioning your code. You can ins
 <CodeGroup>
 
 ```bash CLI
-brew tap Oxen-AI/oxen
 brew install oxen
 ```
 


### PR DESCRIPTION
Now that Oxen is in homebrew-core, we should not direct users to install the deprecated tap.