### PR TITLE
Update inference api docs

### DIFF
--- a/examples/fine-tuning/chat_completions.mdx
+++ b/examples/fine-tuning/chat_completions.mdx
@@ -114,7 +114,7 @@ You can integrate it into your application using the API. The API is OpenAI comp
 For chat completions, you'll send a list of messages that includes the conversation history. Each message should have a `role` (either "user", "assistant", or "system") and `content`.
 
 ```bash
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
 -H "Authorization: Bearer $API_KEY" \
 -H "Content-Type: application/json" \
 -d '{

--- a/examples/fine-tuning/image_editing.mdx
+++ b/examples/fine-tuning/image_editing.mdx
@@ -95,7 +95,7 @@ curl -X POST \
     "input_image": "https://hub.oxen.ai/api/repos/ox/Oxen-Character-Simple-Vector-Graphic/file/main/images/reference/bloxy_white_bg.png",
     "prompt": "Add a funny hat to the ox",
     "num_inference_steps": 20
-    }' https://hub.oxen.ai/api/images/edit
+    }' https://hub.oxen.ai/api/ai/images/edit
 ```
 
 ## Using the Playground

--- a/examples/fine-tuning/image_generation.mdx
+++ b/examples/fine-tuning/image_generation.mdx
@@ -134,7 +134,7 @@ curl -X POST \
   "model": "oxen:ox-brave-jade-gecko",
   "prompt": "A majestic ox standing in a field at sunset",
   "num_inference_steps": 28
-}' https://hub.oxen.ai/api/images/generate
+}' https://hub.oxen.ai/api/ai/images/generate
 ```
 
 ## Using the Playground

--- a/examples/fine-tuning/image_understanding.mdx
+++ b/examples/fine-tuning/image_understanding.mdx
@@ -90,7 +90,7 @@ curl -X POST \
       ]
     }
   ]
-}' https://hub.oxen.ai/api/chat/completions
+}' https://hub.oxen.ai/api/ai/chat/completions
 ```
 
 For more ways to call the API, check out the [inference](/examples/inference/vision_language_models) examples.

--- a/examples/fine-tuning/text_generation.mdx
+++ b/examples/fine-tuning/text_generation.mdx
@@ -93,10 +93,10 @@ This will bring up a chat interface where you can test your model to see how it 
 
 ## Model API
 
-You can integrate it into your application using the API. The API is OpenAI compatible, so you can use any OpenAI client library to interact with it. The base URL for the API is `https://hub.oxen.ai/api`.
+You can integrate it into your application using the API. The API is OpenAI compatible, so you can use any OpenAI client library to interact with it. The base URL for the API is `https://hub.oxen.ai/api/ai`.
 
 ```bash
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
 -H "Authorization: Bearer $API_KEY" \
 -H "Content-Type: application/json" \
 -d '{

--- a/examples/fine-tuning/video_generation.mdx
+++ b/examples/fine-tuning/video_generation.mdx
@@ -122,7 +122,7 @@ curl -X POST \
   "model": "oxen:ox-comfortable-sapphire-locust",
   "prompt": "An ox walking in a field",
   "run_fast": true
-}' https://hub.oxen.ai/api/videos/generate
+}' https://hub.oxen.ai/api/ai/videos/generate
 ```
 
 ## Using the Playground

--- a/examples/inference/chat_completions.mdx
+++ b/examples/inference/chat_completions.mdx
@@ -107,7 +107,7 @@ The API returns an OpenAI-compatible JSON response:
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `model` | string | *required* | Model name, e.g. `"claude-sonnet-4-6"`, `"gpt-4o"`, `"gemini-3-flash-preview"` |
+| `model` | string | *required* | Model name, e.g. `"claude-sonnet-4-6"`, `"gpt-5-4-2026-03-05"`, `"gemini-3-1-flash-lite-preview"` |
 | `messages` | array | *required* | Array of message objects with `role` and `content` |
 | `max_tokens` | integer | model default | Maximum number of tokens to generate |
 | `temperature` | float | model default | Sampling temperature (0-2). Lower is more deterministic. |
@@ -145,7 +145,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "claude-sonnet-4-6",
+    "model": "gemini-3-1-flash-lite-preview",
     "messages": [
       {"role": "user", "content": "Write a haiku about data."}
     ],
@@ -163,7 +163,7 @@ client = OpenAI(
 )
 
 stream = client.chat.completions.create(
-    model="claude-sonnet-4-6",
+    model="gemini-3-1-flash-lite-preview",
     messages=[
         {"role": "user", "content": "Write a haiku about data."}
     ],
@@ -181,7 +181,7 @@ print()
 Each SSE line is prefixed with `data: ` and contains a JSON chunk:
 
 ```json
-data: {"id":"chatcmpl-...","object":"chat.completion.chunk","created":1774040190,"model":"claude-sonnet-4-6","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}
+data: {"id":"chatcmpl-...","object":"chat.completion.chunk","created":1774040190,"model":"gemini-3-1-flash-lite-preview","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}
 ```
 
 The stream ends with:
@@ -192,7 +192,7 @@ data: [DONE]
 
 ## Vision
 
-Models that support vision (such as `gpt-4o` or `claude-sonnet-4-6`) accept images in the `messages` array. For full details and examples including base64 encoding and video understanding, see [Vision Language Models](/examples/inference/vision_language_models).
+Models that support vision (such as `gemini-3-1-pro-preview` or `claude-sonnet-4-6`) accept images in the `messages` array. For full details and examples including base64 encoding and video understanding, see [Vision Language Models](/examples/inference/vision_language_models).
 
 <CodeGroup>
 
@@ -201,7 +201,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-4o",
+    "model": "gemini-3-1-pro-preview",
     "messages": [
       {
         "role": "user",
@@ -224,7 +224,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="gpt-4o",
+    model="gemini-3-1-pro-preview",
     messages=[
         {
             "role": "user",
@@ -261,7 +261,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "claude-sonnet-4-6",
+    "model": "gpt-5-4-2026-03-05",
     "messages": [
       {"role": "user", "content": "What is the weather in Paris?"}
     ],
@@ -293,7 +293,7 @@ Example assistant payload (abbreviated):
       "finish_reason": "tool_calls",
       "index": 0,
       "message": {
-        "content": "I'll check the current weather in Paris for you right away!",
+        "content": null,
         "role": "assistant",
         "tool_calls": [
           {
@@ -301,8 +301,8 @@ Example assistant payload (abbreviated):
               "arguments": "{\"city\":\"Paris\"}",
               "name": "get_weather"
             },
-            "id": "toolu_014F6XpjMvKbTgV7D5wBzqCn",
-            "index": 1,
+            "id": "call_GRNwPXnbuQW4Sa3QNB3FYkYw",
+            "index": 0,
             "type": "function"
           }
         ]
@@ -311,7 +311,7 @@ Example assistant payload (abbreviated):
   ],
   "created": 1774809792,
   "id": "chatcmpl-1ce4aeac-6c34-468a-ba6b-b96c5372a1dc",
-  "model": "claude-sonnet-4-6",
+  "model": "gpt-5-4-2026-03-05",
   "object": "chat.completion",
   "usage": {
     "completion_tokens": 67,
@@ -334,7 +334,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "claude-sonnet-4-6",
+    "model": "gpt-5-4-2026-03-05",
     "messages": [
       {
         "role": "user",
@@ -345,7 +345,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
         "content": null,
         "tool_calls": [
           {
-            "id": "toolu_01ABC",
+            "id": "call_01ABC",
             "type": "function",
             "function": {
               "name": "get_weather",
@@ -356,7 +356,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
       },
       {
         "role": "tool",
-        "tool_call_id": "toolu_01ABC",
+        "tool_call_id": "call_01ABC",
         "content": "{\"temperature_c\": 18, \"conditions\": \"Partly cloudy\"}"
       }
     ],
@@ -417,7 +417,7 @@ def get_weather(city: str) -> str:
 
 while True:
     response = client.chat.completions.create(
-        model="claude-sonnet-4-6",
+        model="gpt-5-4-2026-03-05",
         messages=messages,
         tools=tools
     )

--- a/examples/inference/chat_completions.mdx
+++ b/examples/inference/chat_completions.mdx
@@ -1,22 +1,22 @@
 ---
 title: '💬 Chat Completions'
-description: 'Integrate an LLM into your application through the `/chat/completions` API.'
+description: 'Integrate an LLM into your application through the `/ai/chat/completions` API.'
 ---
 
 ## Quick Start
 
 The Oxen.ai chat completions API is fully [OpenAI-compatible](https://platform.openai.com/docs/api-reference/chat). You can use the OpenAI SDK, `curl`, or any HTTP client that speaks the OpenAI chat format.
 
-**Base URL:** `https://hub.oxen.ai/api`
+**Base URL:** `https://hub.oxen.ai/api/ai`
 
-**Endpoint:** `POST /chat/completions`
+**Endpoint:** `POST /ai/chat/completions`
 
 Browse [all available models](https://www.oxen.ai/ai/models).
 
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -33,7 +33,7 @@ import os
 
 client = OpenAI(
     api_key=os.environ["OXEN_API_KEY"],
-    base_url="https://hub.oxen.ai/api",
+    base_url="https://hub.oxen.ai/api/ai",
 )
 
 response = client.chat.completions.create(
@@ -141,7 +141,7 @@ Set `"stream": true` to receive responses as server-sent events (SSE). Each even
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -159,7 +159,7 @@ import os
 
 client = OpenAI(
     api_key=os.environ["OXEN_API_KEY"],
-    base_url="https://hub.oxen.ai/api",
+    base_url="https://hub.oxen.ai/api/ai",
 )
 
 stream = client.chat.completions.create(
@@ -197,7 +197,7 @@ Models that support vision (such as `gpt-4o` or `claude-sonnet-4-6`) accept imag
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -220,7 +220,7 @@ import os
 
 client = OpenAI(
     api_key=os.environ["OXEN_API_KEY"],
-    base_url="https://hub.oxen.ai/api",
+    base_url="https://hub.oxen.ai/api/ai",
 )
 
 response = client.chat.completions.create(
@@ -257,7 +257,7 @@ Tool calling (function calling) follows the same [OpenAI Chat Completions tool f
 The model may respond with `tool_calls` instead of user-facing `content`:
 
 ```bash
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -330,7 +330,7 @@ The follow-up HTTP body matches what the OpenAI SDK builds when you append assis
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -389,7 +389,7 @@ import os
 
 client = OpenAI(
     api_key=os.environ["OXEN_API_KEY"],
-    base_url="https://hub.oxen.ai/api",
+    base_url="https://hub.oxen.ai/api/ai",
 )
 
 tools = [

--- a/examples/inference/image_editing.mdx
+++ b/examples/inference/image_editing.mdx
@@ -11,7 +11,7 @@ The image editing endpoint allows you to edit images using AI models. Simply pro
 
 ```bash cURL
 curl -X POST \
-  https://hub.oxen.ai/api/images/edit \
+  https://hub.oxen.ai/api/ai/images/edit \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -d '{
@@ -27,7 +27,7 @@ import requests
 import os
 
 response = requests.post(
-    "https://hub.oxen.ai/api/images/edit",
+    "https://hub.oxen.ai/api/ai/images/edit",
     headers={
         "Authorization": f"Bearer {os.getenv('OXEN_API_KEY')}",
         "Content-Type": "application/json"
@@ -53,7 +53,7 @@ For models that support multiple input images, you can pass an array of image UR
 
 ```bash cURL (multiple images)
 curl -X POST \
-  https://hub.oxen.ai/api/images/edit \
+  https://hub.oxen.ai/api/ai/images/edit \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -d '{
@@ -72,7 +72,7 @@ import requests
 import os
 
 response = requests.post(
-    "https://hub.oxen.ai/api/images/edit",
+    "https://hub.oxen.ai/api/ai/images/edit",
     headers={
         "Authorization": f"Bearer {os.getenv('OXEN_API_KEY')}",
         "Content-Type": "application/json"

--- a/examples/inference/image_generation.mdx
+++ b/examples/inference/image_generation.mdx
@@ -11,7 +11,7 @@ The image generation endpoint allows you to generate images from text prompts. S
 
 ```bash cURL
 curl -X POST \
-  https://hub.oxen.ai/api/images/generate \
+  https://hub.oxen.ai/api/ai/images/generate \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -d '{
@@ -26,7 +26,7 @@ import requests
 import os
 
 response = requests.post(
-    "https://hub.oxen.ai/api/images/generate",
+    "https://hub.oxen.ai/api/ai/images/generate",
     headers={
         "Authorization": f"Bearer {os.getenv('OXEN_API_KEY')}",
         "Content-Type": "application/json"

--- a/examples/inference/video_generation.mdx
+++ b/examples/inference/video_generation.mdx
@@ -15,7 +15,7 @@ Video generation can take a few minutes to generate, depending on the model. So 
 
 ```bash cURL
 curl -X POST \
-  https://hub.oxen.ai/api/videos/generate \
+  https://hub.oxen.ai/api/ai/videos/generate \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -d '{
@@ -30,7 +30,7 @@ import requests
 import os
 
 response = requests.post(
-    "https://hub.oxen.ai/api/videos/generate",
+    "https://hub.oxen.ai/api/ai/videos/generate",
     headers={
         "Authorization": f"Bearer {os.getenv('OXEN_API_KEY')}",
         "Content-Type": "application/json"

--- a/examples/inference/vision_language_models.mdx
+++ b/examples/inference/vision_language_models.mdx
@@ -1,6 +1,6 @@
 ---
 title: '👁️ Vision Language Models'
-description: 'Leverage image understanding with the `/chat/completions` endpoint.'
+description: 'Leverage image understanding with the `/ai/chat/completions` endpoint.'
 ---
 
 ## What are VLMs?
@@ -13,14 +13,14 @@ Here is the [list of supported models](https://www.oxen.ai/ai/models?modalities=
 
 ## Image Understanding
 
-The `/chat/completions` endpoint supports vision language models for image understanding. If you want to send an image to a model that supports vision such as Qwen3-VL, Qwen3.5, or Gemini 3 Pro/Flash, you can add a message with the `image_url` type.
+The `/ai/chat/completions` endpoint supports vision language models for image understanding. If you want to send an image to a model that supports vision such as Qwen3-VL, Qwen3.5, or Gemini 3 Pro/Flash, you can add a message with the `image_url` type.
 
 ### Using Image URLs
 
 <CodeGroup>
 
 ```bash cURL (image url)
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
 -H "Authorization: Bearer $OXEN_API_KEY" \
 -H "Content-Type: application/json" \
 -d '{
@@ -53,7 +53,7 @@ You can also directly pass in the base64 encoded image.
 
 <CodeGroup>
 ```bash cURL (base64 encoded image)
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
 -H "Authorization: Bearer $OXEN_API_KEY" \
 -H "Content-Type: application/json" \
 -d '{
@@ -97,7 +97,7 @@ def encode_image(image_path):
 # Initialize the client
 client = openai.OpenAI(
     api_key=os.getenv("OXEN_API_KEY"),
-    base_url="https://hub.oxen.ai/api"
+    base_url="https://hub.oxen.ai/api/ai"
 )
 
 # Encode your image
@@ -131,14 +131,14 @@ print(response.choices[0].message.content)
 
 ## Video Understanding
 
-The `/chat/completions` endpoint also supports video understanding through vision language models. To send a video to a model that supports video understanding, you can add a message with the `video_url` type.
+The `/ai/chat/completions` endpoint also supports video understanding through vision language models. To send a video to a model that supports video understanding, you can add a message with the `video_url` type.
 
 ### Using Video URLs
 
 <CodeGroup>
 
 ```bash cURL (video url)
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
 -H "Authorization: Bearer $OXEN_API_KEY" \
 -H "Content-Type: application/json" \
 -d '{
@@ -171,7 +171,7 @@ You can also directly pass in the base64 encoded video.
 
 <CodeGroup>
 ```bash cURL (base64 encoded video)
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
 -H "Authorization: Bearer $OXEN_API_KEY" \
 -H "Content-Type: application/json" \
 -d '{
@@ -215,7 +215,7 @@ def encode_video(video_path):
 # Initialize the client
 client = openai.OpenAI(
     api_key=os.getenv("OXEN_API_KEY"),
-    base_url="https://hub.oxen.ai/api"
+    base_url="https://hub.oxen.ai/api/ai"
 )
 
 # Encode your video

--- a/fine-tuning-api/02_fine_tuning_image.mdx
+++ b/fine-tuning-api/02_fine_tuning_image.mdx
@@ -258,7 +258,7 @@ With the deployment live, you can call the **image editing** inference endpoint 
 
 **Endpoint**
 
-- `POST /api/images/edit`
+- `POST /api/ai/images/edit`
 
 **Example `curl` request** (single input image):
 
@@ -266,7 +266,7 @@ With the deployment live, you can call the **image editing** inference endpoint 
 export DEPLOYED_MODEL="${DEPLOYED_MODEL:-oxen:your-fine-tuned-image-edit-model}"
 
 curl -X POST \
-  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/images/edit" \
+  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/ai/images/edit" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${OXEN_API_KEY}" \
   -d "{
@@ -281,7 +281,7 @@ For models that support **multiple input images** (for example when using a mult
 
 ```bash
 curl -X POST \
-  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/images/edit" \
+  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/ai/images/edit" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${OXEN_API_KEY}" \
   -d "{

--- a/fine-tuning-api/tutorials/02_fine_tuning_image.mdx
+++ b/fine-tuning-api/tutorials/02_fine_tuning_image.mdx
@@ -258,7 +258,7 @@ With the deployment live, you can call the **image editing** inference endpoint 
 
 **Endpoint**
 
-- `POST /api/images/edit`
+- `POST /api/ai/images/edit`
 
 **Example `curl` request** (single input image):
 
@@ -266,7 +266,7 @@ With the deployment live, you can call the **image editing** inference endpoint 
 export DEPLOYED_MODEL="${DEPLOYED_MODEL:-oxen:your-fine-tuned-image-edit-model}"
 
 curl -X POST \
-  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/images/edit" \
+  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/ai/images/edit" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${OXEN_API_KEY}" \
   -d "{
@@ -281,7 +281,7 @@ For models that support **multiple input images** (for example when using a mult
 
 ```bash
 curl -X POST \
-  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/images/edit" \
+  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/ai/images/edit" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${OXEN_API_KEY}" \
   -d "{

--- a/fine-tuning-api/tutorials/03_fine_tuning_image_generation.mdx
+++ b/fine-tuning-api/tutorials/03_fine_tuning_image_generation.mdx
@@ -295,7 +295,7 @@ The response will include deployment information with a **model identifier** you
   "deployment": {
     "model_slug": "oxen:tutorials/cyberpunkart-ft_img_gen_12345",
     "status": "deploying",
-    "endpoint": "https://hub.oxen.ai/api/images/generate"
+    "endpoint": "https://hub.oxen.ai/api/ai/images/generate"
   }
 }
 ```
@@ -319,13 +319,13 @@ Now you can generate images in your custom style using the inference API.
 
 **Endpoint**
 
-- `POST /api/images/generate`
+- `POST /api/ai/images/generate`
 
 **Example `curl` request** (text-to-image):
 
 ```bash
 curl -X POST \
-  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/images/generate" \
+  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/ai/images/generate" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${OXEN_API_KEY}" \
   -d "{
@@ -344,7 +344,7 @@ You can generate multiple variations by setting `num_images`:
 
 ```bash
 curl -X POST \
-  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/images/generate" \
+  "${OXEN_BASE_URL:-https://hub.oxen.ai}/api/ai/images/generate" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${OXEN_API_KEY}" \
   -d "{
@@ -479,7 +479,7 @@ time.sleep(60)
 
 # Step 5: Generate image
 print("Generating image...")
-generate_url = f"{BASE_URL}/api/images/generate"
+generate_url = f"{BASE_URL}/api/ai/images/generate"
 gen_data = {
     "model": deployed_model,
     "prompt": "a motorcycle racing through the city in cyberpunk style",

--- a/getting-started/batch_inference.mdx
+++ b/getting-started/batch_inference.mdx
@@ -70,7 +70,7 @@ curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/jso
     "name": "My Awesome Evaluation",
     "prompt": "Classify the following text into one of the following categories: [intent_1, intent_2, intent_3]\n{my_text_column_name}",
     "type": "text",
-    "model": "gpt-4o-mini",
+    "model": "gemini-3-1-flash-lite-preview",
     "is_sample": false,
     "target_column": "prediction",
     "target_branch": "api-results-branch",

--- a/getting-started/fine-tuning.mdx
+++ b/getting-started/fine-tuning.mdx
@@ -107,7 +107,7 @@ Click on the "Info" tab to see the fine-tuning configuration and all the hyper-p
 
 Once the model is fine-tuned, you can deploy it to a dedicated endpoint or in the playground. 
 
-This will give you a `/chat/completions` api and a playgroud that you can use to test out the model.
+This will give you a `/ai/chat/completions` api and a playground that you can use to test out the model.
 
 Start by using the "playgroud" button.
 <img alt="Fine-Tuning Configuration" className="rounded-xl" src="/images/fine_tuning/fine-tune-deploy-model.png" />
@@ -124,7 +124,7 @@ use the activate button to load the model.
 To use the API Swap out the model name with the name of the model you want to use.
 
 ```bash
-curl https://hub.oxen.ai/api/chat/completions -H "Content-Type: application/json" -d '{
+curl https://hub.oxen.ai/api/ai/chat/completions -H "Content-Type: application/json" -d '{
     "model":"oxen:my-model-name",
     "messages": [{"role": "user", "content": "What is the best name for a friendly ox?"}],
 }'

--- a/inference-api/overview.mdx
+++ b/inference-api/overview.mdx
@@ -19,24 +19,38 @@ All requests require a bearer token:
 
 ```bash
 curl -H "Authorization: Bearer YOUR_API_KEY" \
-  https://hub.oxen.ai/api/...
+  https://hub.oxen.ai/api/ai/...
 ```
 
 Get your API key from your [account settings](https://oxen.ai/settings).
+
+## Base URL
+
+All inference endpoints live under:
+
+```
+https://hub.oxen.ai/api/ai
+```
+
+If you're using the OpenAI SDK, set the base URL to `https://hub.oxen.ai/api/ai` — the SDK appends `/chat/completions` automatically.
 
 ## Endpoints
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/chat/completions` | POST | Text generation (chat, vision, tool use) |
-| `/images/generate` | POST | Image generation |
-| `/images/edit` | POST | Image editing |
-| `/videos/generate` | POST | Video generation |
+| `/ai/chat/completions` | POST | Text generation (chat, vision, tool use) |
+| `/ai/images/generate` | POST | Image generation |
+| `/ai/images/edit` | POST | Image editing |
+| `/ai/videos/generate` | POST | Video generation |
 | `/ai/queue` | POST | Async image/video generation |
-| `/media/generations/status/:namespace/*model_name` | GET | Poll async generation status |
-| `/media/generations/:namespace/:generation_id` | DELETE | Cancel a queued generation |
-| `/evaluations/models` | GET | List available models |
-| `/evaluations/models/:id` | GET | Get model details and parameter schema |
+| `/ai/queue` | GET | List queued generations |
+| `/ai/queue/:generation_id` | GET | Get generation status |
+| `/ai/queue/:generation_id` | DELETE | Cancel a queued generation |
+| `/ai/models` | GET | List available models |
+| `/ai/models/:id` | GET | Get model details and parameter schema |
+| `/ai/models/search` | GET | Search models by name |
+| `/ai/models/:id/activate` | POST | Activate a custom model deployment |
+| `/ai/models/:id/deactivate` | POST | Deactivate a custom model deployment |
 
 ## Common Parameters
 
@@ -50,26 +64,26 @@ These parameters are accepted across multiple endpoints:
 
 ## Discovering Models
 
-List all models, optionally filtered by capability:
+List all models, optionally filtered by developer:
 
 ```bash
-# All video models
+# All models
 curl -H "Authorization: Bearer $OXEN_API_KEY" \
-  "https://hub.oxen.ai/api/evaluations/models?output_capability=video"
+  "https://hub.oxen.ai/api/ai/models"
 
 # Search by name
 curl -H "Authorization: Bearer $OXEN_API_KEY" \
-  "https://hub.oxen.ai/api/evaluations/models/search?search=kling"
+  "https://hub.oxen.ai/api/ai/models/search?search=kling"
 ```
 
 Get full details for a specific model (including its parameter schema):
 
 ```bash
 curl -H "Authorization: Bearer $OXEN_API_KEY" \
-  "https://hub.oxen.ai/api/evaluations/models/kling-video-o3-pro-reference-to-video"
+  "https://hub.oxen.ai/api/ai/models/kling-video-o3-pro-reference-to-video"
 ```
 
-The response includes a `json_request_schema` field with the complete parameter definitions, types, defaults, and constraints for that model.
+The response includes a `request_schema` field with the complete parameter definitions, types, defaults, and constraints for that model.
 
 ## Pricing
 
@@ -81,7 +95,7 @@ Pricing varies by model:
 | `per_image` | Fixed cost per image | FLUX, DALL-E |
 | `per_video_output_second` | Cost per second of output video | Kling, Sora |
 
-Check the model detail endpoint for exact pricing. Relevant fields: `input_cost_per_token`, `output_cost_per_token`, `cost_per_image`, `video_cost_per_second`, `video_cost_per_second_with_audio`, `video_cost_per_second_high_res`.
+Check the [model detail endpoint](/inference-api/reference/models#retrieve-model) for exact pricing. Relevant fields: `input_cost_per_token`, `output_cost_per_token`, `cost_per_image`, `cost_per_second`, `cost_per_second_with_audio`, `cost_per_second_high_res`.
 
 ## Error Format
 
@@ -124,7 +138,7 @@ Common error types: `unauthenticated`, `invalid_params`, `resource_not_found`, `
 
 ## API Reference
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Chat Completions" icon="message" href="/inference-api/reference/chat_completions">
     Text generation, vision, tool calling
   </Card>
@@ -139,6 +153,9 @@ Common error types: `unauthenticated`, `invalid_params`, `resource_not_found`, `
   </Card>
   <Card title="Async Queue" icon="layer-group" href="/inference-api/reference/async_queue">
     Background image/video generation
+  </Card>
+  <Card title="Models" icon="cube" href="/inference-api/reference/models">
+    List, search, and manage models
   </Card>
 </CardGroup>
 

--- a/inference-api/overview.mdx
+++ b/inference-api/overview.mdx
@@ -60,7 +60,7 @@ The Inference API gives you access to hundreds of AI models through a single, co
 
 ---
 
-The rest of this page covers authentication, base URLs, endpoint details, and pricing — everything you need to start making requests.
+The rest of this page covers authentication, base URLs, endpoint details, and pricing: everything you need to start making requests.
 
 ## Authentication
 
@@ -81,7 +81,7 @@ All inference endpoints live under:
 https://hub.oxen.ai/api/ai
 ```
 
-If you're using the OpenAI SDK, set the base URL to `https://hub.oxen.ai/api/ai` — the SDK appends `/chat/completions` automatically.
+If you're using the OpenAI SDK, set the base URL to `https://hub.oxen.ai/api/ai`. The SDK appends `/chat/completions` automatically.
 
 ## Endpoints
 

--- a/inference-api/overview.mdx
+++ b/inference-api/overview.mdx
@@ -13,6 +13,51 @@ The Inference API gives you access to hundreds of AI models through a single, co
 - **Image Generation**: Text-to-image, image-to-image editing
 - **Video Generation**: Text-to-video, image-to-video, reference-to-video, video-to-video editing
 
+## Quick Starts
+
+<CardGroup cols={3}>
+  <Card title="Chat" icon="message" href="/inference-api/quickstart/chat">
+    Text generation in minutes
+  </Card>
+  <Card title="Image Generation" icon="image" href="/inference-api/quickstart/image-generation">
+    Text-to-image in minutes
+  </Card>
+  <Card title="Video Generation" icon="video" href="/inference-api/quickstart/video-generation">
+    Text-to-video in minutes
+  </Card>
+</CardGroup>
+
+## API Reference
+
+<CardGroup cols={3}>
+  <Card title="Chat Completions" icon="message" href="/inference-api/reference/chat_completions">
+    Text generation, vision, tool calling
+  </Card>
+  <Card title="Image Generation" icon="image" href="/inference-api/reference/image_generation">
+    Text-to-image generation
+  </Card>
+  <Card title="Image Editing" icon="wand-magic-sparkles" href="/inference-api/reference/image_editing">
+    Edit images with text prompts
+  </Card>
+  <Card title="Video Generation" icon="video" href="/inference-api/reference/video_generation">
+    Text-to-video, image-to-video, multi-shot
+  </Card>
+  <Card title="Async Queue" icon="layer-group" href="/inference-api/reference/async_queue">
+    Background image/video generation
+  </Card>
+  <Card title="Models" icon="cube" href="/inference-api/reference/models/overview">
+    List, search, and manage models
+  </Card>
+</CardGroup>
+
+## Model References
+
+<CardGroup cols={2}>
+  <Card title="Kling O3 Pro: Reference to Video" icon="film" href="/inference-api/reference/models/kling_o3_pro_reference_to_video">
+    Multi-shot video with reference images, elements, and audio
+  </Card>
+</CardGroup>
+
 ## Authentication
 
 All requests require a bearer token:
@@ -121,50 +166,5 @@ Errors use one of two formats:
 ```
 
 Common error types: `unauthenticated`, `invalid_params`, `resource_not_found`, `unknown_error`.
-
-## Quick Starts
-
-<CardGroup cols={3}>
-  <Card title="Chat" icon="message" href="/inference-api/quickstart/chat">
-    Text generation in minutes
-  </Card>
-  <Card title="Image Generation" icon="image" href="/inference-api/quickstart/image-generation">
-    Text-to-image in minutes
-  </Card>
-  <Card title="Video Generation" icon="video" href="/inference-api/quickstart/video-generation">
-    Text-to-video in minutes
-  </Card>
-</CardGroup>
-
-## API Reference
-
-<CardGroup cols={3}>
-  <Card title="Chat Completions" icon="message" href="/inference-api/reference/chat_completions">
-    Text generation, vision, tool calling
-  </Card>
-  <Card title="Image Generation" icon="image" href="/inference-api/reference/image_generation">
-    Text-to-image generation
-  </Card>
-  <Card title="Image Editing" icon="wand-magic-sparkles" href="/inference-api/reference/image_editing">
-    Edit images with text prompts
-  </Card>
-  <Card title="Video Generation" icon="video" href="/inference-api/reference/video_generation">
-    Text-to-video, image-to-video, multi-shot
-  </Card>
-  <Card title="Async Queue" icon="layer-group" href="/inference-api/reference/async_queue">
-    Background image/video generation
-  </Card>
-  <Card title="Models" icon="cube" href="/inference-api/reference/models/overview">
-    List, search, and manage models
-  </Card>
-</CardGroup>
-
-## Model References
-
-<CardGroup cols={2}>
-  <Card title="Kling O3 Pro: Reference to Video" icon="film" href="/inference-api/reference/models/kling_o3_pro_reference_to_video">
-    Multi-shot video with reference images, elements, and audio
-  </Card>
-</CardGroup>
 
 Need help? Join our [Discord community](https://discord.com/invite/s3tBEn7Ptg).

--- a/inference-api/overview.mdx
+++ b/inference-api/overview.mdx
@@ -13,19 +13,6 @@ The Inference API gives you access to hundreds of AI models through a single, co
 - **Image Generation**: Text-to-image, image-to-image editing
 - **Video Generation**: Text-to-video, image-to-video, reference-to-video, video-to-video editing
 
-## Try It
-
-Get your API key from your [account settings](https://oxen.ai/settings), then:
-
-```bash
-curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
-  -H "Authorization: Bearer YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"model": "claude-sonnet-4-6", "messages": [{"role": "user", "content": "Hello!"}]}'
-```
-
-That's it. The API is OpenAI-compatible, so any OpenAI SDK works too. Just set the base URL to `https://hub.oxen.ai/api/ai`.
-
 ## Quick Starts
 
 <CardGroup cols={3}>
@@ -71,6 +58,80 @@ That's it. The API is OpenAI-compatible, so any OpenAI SDK works too. Just set t
   </Card>
 </CardGroup>
 
+---
+
+## Authentication
+
+All requests require a bearer token:
+
+```bash
+curl -H "Authorization: Bearer YOUR_API_KEY" \
+  https://hub.oxen.ai/api/ai/...
+```
+
+Get your API key from your [account settings](https://oxen.ai/settings).
+
+## Base URL
+
+All inference endpoints live under:
+
+```
+https://hub.oxen.ai/api/ai
+```
+
+If you're using the OpenAI SDK, set the base URL to `https://hub.oxen.ai/api/ai`. The SDK appends `/chat/completions` automatically.
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/ai/chat/completions` | POST | Text generation (chat, vision, tool use) |
+| `/ai/images/generate` | POST | Image generation |
+| `/ai/images/edit` | POST | Image editing |
+| `/ai/videos/generate` | POST | Video generation |
+| `/ai/queue` | POST | Async image/video generation |
+| `/ai/queue` | GET | List queued generations |
+| `/ai/queue/:generation_id` | GET | Get generation status |
+| `/ai/queue/:generation_id` | DELETE | Cancel a queued generation |
+| `/ai/models` | GET | List available models |
+| `/ai/models/:id` | GET | Get model details and parameter schema |
+| `/ai/models/search` | GET | Search models by name |
+| `/ai/models/:id/activate` | POST | Activate a custom model deployment |
+| `/ai/models/:id/deactivate` | POST | Deactivate a custom model deployment |
+
+## Common Parameters
+
+These parameters are accepted across multiple endpoints:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `model` | string | Required. The model to use (e.g. `claude-sonnet-4-6`, `flux-2-dev`, `kling-video-o3-pro-reference-to-video`). |
+| `response_format` | string | `"url"` (default) returns a hosted URL. `"b64_json"` returns base64-encoded bytes inline. Supported on image and video endpoints. |
+| `target_namespace` | string | Namespace to save results and bill to. Defaults to your user. Can be an organization name. |
+
+## Discovering Models
+
+List all models, optionally filtered by developer:
+
+```bash
+# All models
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/models"
+
+# Search by name
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/models/search?search=kling"
+```
+
+Get full details for a specific model (including its parameter schema):
+
+```bash
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/models/kling-video-o3-pro-reference-to-video"
+```
+
+The response includes a `request_schema` field with the complete parameter definitions, types, defaults, and constraints for that model.
+
 ## Pricing
 
 Pricing varies by model:
@@ -81,6 +142,31 @@ Pricing varies by model:
 | `per_image` | Fixed cost per image | FLUX, DALL-E |
 | `per_video_output_second` | Cost per second of output video | Kling, Sora |
 
-Check the [model detail endpoint](/inference-api/reference/models/overview#retrieve-model) for exact pricing.
+Check the [model detail endpoint](/inference-api/reference/models/overview#retrieve-model) for exact pricing. Relevant fields: `input_cost_per_token`, `output_cost_per_token`, `cost_per_image`, `cost_per_second`, `cost_per_second_with_audio`, `cost_per_second_high_res`.
+
+## Error Format
+
+Errors use one of two formats:
+
+```json
+{
+  "error": {
+    "type": "invalid_params",
+    "title": "Invalid parameters supplied, please check your request and try again.",
+    "detail": "Specific error details"
+  },
+  "status": "error"
+}
+```
+
+```json
+{
+  "error": {
+    "message": "Model not found: bad-model-name"
+  }
+}
+```
+
+Common error types: `unauthenticated`, `invalid_params`, `resource_not_found`, `unknown_error`.
 
 Need help? Join our [Discord community](https://discord.com/invite/s3tBEn7Ptg).

--- a/inference-api/overview.mdx
+++ b/inference-api/overview.mdx
@@ -13,6 +13,19 @@ The Inference API gives you access to hundreds of AI models through a single, co
 - **Image Generation**: Text-to-image, image-to-image editing
 - **Video Generation**: Text-to-video, image-to-video, reference-to-video, video-to-video editing
 
+## Try It
+
+Get your API key from your [account settings](https://oxen.ai/settings), then:
+
+```bash
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "claude-sonnet-4-6", "messages": [{"role": "user", "content": "Hello!"}]}'
+```
+
+That's it. The API is OpenAI-compatible, so any OpenAI SDK works too. Just set the base URL to `https://hub.oxen.ai/api/ai`.
+
 ## Quick Starts
 
 <CardGroup cols={3}>
@@ -58,82 +71,6 @@ The Inference API gives you access to hundreds of AI models through a single, co
   </Card>
 </CardGroup>
 
----
-
-The rest of this page covers authentication, base URLs, endpoint details, and pricing: everything you need to start making requests.
-
-## Authentication
-
-All requests require a bearer token:
-
-```bash
-curl -H "Authorization: Bearer YOUR_API_KEY" \
-  https://hub.oxen.ai/api/ai/...
-```
-
-Get your API key from your [account settings](https://oxen.ai/settings).
-
-## Base URL
-
-All inference endpoints live under:
-
-```
-https://hub.oxen.ai/api/ai
-```
-
-If you're using the OpenAI SDK, set the base URL to `https://hub.oxen.ai/api/ai`. The SDK appends `/chat/completions` automatically.
-
-## Endpoints
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/ai/chat/completions` | POST | Text generation (chat, vision, tool use) |
-| `/ai/images/generate` | POST | Image generation |
-| `/ai/images/edit` | POST | Image editing |
-| `/ai/videos/generate` | POST | Video generation |
-| `/ai/queue` | POST | Async image/video generation |
-| `/ai/queue` | GET | List queued generations |
-| `/ai/queue/:generation_id` | GET | Get generation status |
-| `/ai/queue/:generation_id` | DELETE | Cancel a queued generation |
-| `/ai/models` | GET | List available models |
-| `/ai/models/:id` | GET | Get model details and parameter schema |
-| `/ai/models/search` | GET | Search models by name |
-| `/ai/models/:id/activate` | POST | Activate a custom model deployment |
-| `/ai/models/:id/deactivate` | POST | Deactivate a custom model deployment |
-
-## Common Parameters
-
-These parameters are accepted across multiple endpoints:
-
-| Parameter | Type | Description |
-|---|---|---|
-| `model` | string | Required. The model to use (e.g. `claude-sonnet-4-6`, `flux-2-dev`, `kling-video-o3-pro-reference-to-video`). |
-| `response_format` | string | `"url"` (default) returns a hosted URL. `"b64_json"` returns base64-encoded bytes inline. Supported on image and video endpoints. |
-| `target_namespace` | string | Namespace to save results and bill to. Defaults to your user. Can be an organization name. |
-
-## Discovering Models
-
-List all models, optionally filtered by developer:
-
-```bash
-# All models
-curl -H "Authorization: Bearer $OXEN_API_KEY" \
-  "https://hub.oxen.ai/api/ai/models"
-
-# Search by name
-curl -H "Authorization: Bearer $OXEN_API_KEY" \
-  "https://hub.oxen.ai/api/ai/models/search?search=kling"
-```
-
-Get full details for a specific model (including its parameter schema):
-
-```bash
-curl -H "Authorization: Bearer $OXEN_API_KEY" \
-  "https://hub.oxen.ai/api/ai/models/kling-video-o3-pro-reference-to-video"
-```
-
-The response includes a `request_schema` field with the complete parameter definitions, types, defaults, and constraints for that model.
-
 ## Pricing
 
 Pricing varies by model:
@@ -144,31 +81,6 @@ Pricing varies by model:
 | `per_image` | Fixed cost per image | FLUX, DALL-E |
 | `per_video_output_second` | Cost per second of output video | Kling, Sora |
 
-Check the [model detail endpoint](/inference-api/reference/models/overview#retrieve-model) for exact pricing. Relevant fields: `input_cost_per_token`, `output_cost_per_token`, `cost_per_image`, `cost_per_second`, `cost_per_second_with_audio`, `cost_per_second_high_res`.
-
-## Error Format
-
-Errors use one of two formats:
-
-```json
-{
-  "error": {
-    "type": "invalid_params",
-    "title": "Invalid parameters supplied, please check your request and try again.",
-    "detail": "Specific error details"
-  },
-  "status": "error"
-}
-```
-
-```json
-{
-  "error": {
-    "message": "Model not found: bad-model-name"
-  }
-}
-```
-
-Common error types: `unauthenticated`, `invalid_params`, `resource_not_found`, `unknown_error`.
+Check the [model detail endpoint](/inference-api/reference/models/overview#retrieve-model) for exact pricing.
 
 Need help? Join our [Discord community](https://discord.com/invite/s3tBEn7Ptg).

--- a/inference-api/overview.mdx
+++ b/inference-api/overview.mdx
@@ -56,6 +56,15 @@ The Inference API gives you access to hundreds of AI models through a single, co
   <Card title="Kling O3 Pro: Reference to Video" icon="film" href="/inference-api/reference/models/kling_o3_pro_reference_to_video">
     Multi-shot video with reference images, elements, and audio
   </Card>
+  <Card title="Kling O3 Pro: Video to Video Edit" icon="pen-to-square" href="/inference-api/reference/models/kling_o3_pro_video_to_video_edit">
+    Edit existing videos with text instructions and reference images
+  </Card>
+  <Card title="Seedance 2.0: Reference to Video" icon="seedling" href="/inference-api/reference/models/seedance_2_reference_to_video">
+    Generate video from text, images, video, and audio references
+  </Card>
+  <Card title="Topaz Starlight Precise 2.5" icon="arrow-up-right-dots" href="/inference-api/reference/models/topaz_starlight_precise_2_5">
+    Video upscaling and restoration up to 4K
+  </Card>
 </CardGroup>
 
 ---
@@ -139,6 +148,7 @@ Pricing varies by model:
 | Method | How it works | Examples |
 |---|---|---|
 | `token` | Per input/output token | GPT, Claude, Gemini |
+| `time` | Per second of compute time | Custom models, Llama, Qwen |
 | `per_image` | Fixed cost per image | FLUX, DALL-E |
 | `per_video_output_second` | Cost per second of output video | Kling, Sora |
 
@@ -155,7 +165,8 @@ Errors use one of two formats:
     "title": "Invalid parameters supplied, please check your request and try again.",
     "detail": "Specific error details"
   },
-  "status": "error"
+  "status": "error",
+  "status_message": "invalid_params"
 }
 ```
 

--- a/inference-api/overview.mdx
+++ b/inference-api/overview.mdx
@@ -58,6 +58,10 @@ The Inference API gives you access to hundreds of AI models through a single, co
   </Card>
 </CardGroup>
 
+---
+
+The rest of this page covers authentication, base URLs, endpoint details, and pricing — everything you need to start making requests.
+
 ## Authentication
 
 All requests require a bearer token:

--- a/inference-api/overview.mdx
+++ b/inference-api/overview.mdx
@@ -58,7 +58,7 @@ These parameters are accepted across multiple endpoints:
 
 | Parameter | Type | Description |
 |---|---|---|
-| `model` | string | Required. The model to use (e.g. `gpt-4o-mini`, `flux-2-dev`, `kling-video-o3-pro-reference-to-video`). |
+| `model` | string | Required. The model to use (e.g. `claude-sonnet-4-6`, `flux-2-dev`, `kling-video-o3-pro-reference-to-video`). |
 | `response_format` | string | `"url"` (default) returns a hosted URL. `"b64_json"` returns base64-encoded bytes inline. Supported on image and video endpoints. |
 | `target_namespace` | string | Namespace to save results and bill to. Defaults to your user. Can be an organization name. |
 

--- a/inference-api/overview.mdx
+++ b/inference-api/overview.mdx
@@ -95,7 +95,7 @@ Pricing varies by model:
 | `per_image` | Fixed cost per image | FLUX, DALL-E |
 | `per_video_output_second` | Cost per second of output video | Kling, Sora |
 
-Check the [model detail endpoint](/inference-api/reference/models#retrieve-model) for exact pricing. Relevant fields: `input_cost_per_token`, `output_cost_per_token`, `cost_per_image`, `cost_per_second`, `cost_per_second_with_audio`, `cost_per_second_high_res`.
+Check the [model detail endpoint](/inference-api/reference/models/overview#retrieve-model) for exact pricing. Relevant fields: `input_cost_per_token`, `output_cost_per_token`, `cost_per_image`, `cost_per_second`, `cost_per_second_with_audio`, `cost_per_second_high_res`.
 
 ## Error Format
 
@@ -154,7 +154,7 @@ Common error types: `unauthenticated`, `invalid_params`, `resource_not_found`, `
   <Card title="Async Queue" icon="layer-group" href="/inference-api/reference/async_queue">
     Background image/video generation
   </Card>
-  <Card title="Models" icon="cube" href="/inference-api/reference/models">
+  <Card title="Models" icon="cube" href="/inference-api/reference/models/overview">
     List, search, and manage models
   </Card>
 </CardGroup>

--- a/inference-api/quickstart/chat.mdx
+++ b/inference-api/quickstart/chat.mdx
@@ -15,7 +15,7 @@ Generate text responses from language models using the OpenAI-compatible chat co
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://hub.oxen.ai/api",
+    base_url="https://hub.oxen.ai/api/ai",
     api_key="YOUR_API_KEY",
 )
 
@@ -29,7 +29,7 @@ print(response.choices[0].message.content)
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -49,7 +49,7 @@ curl -X POST https://hub.oxen.ai/api/chat/completions \
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://hub.oxen.ai/api",
+    base_url="https://hub.oxen.ai/api/ai",
     api_key="YOUR_API_KEY",
 )
 
@@ -67,7 +67,7 @@ print()
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/inference-api/quickstart/chat.mdx
+++ b/inference-api/quickstart/chat.mdx
@@ -20,7 +20,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="gpt-4o-mini",
+    model="claude-sonnet-4-6",
     messages=[{"role": "user", "content": "What is Oxen.ai?"}],
     max_tokens=200,
 )
@@ -33,7 +33,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-4o-mini",
+    "model": "claude-sonnet-4-6",
     "messages": [{"role": "user", "content": "What is Oxen.ai?"}],
     "max_tokens": 200
   }'
@@ -54,7 +54,7 @@ client = OpenAI(
 )
 
 stream = client.chat.completions.create(
-    model="gpt-4o-mini",
+    model="gemini-3-1-flash-lite-preview",
     messages=[{"role": "user", "content": "Write a haiku about data"}],
     stream=True,
 )
@@ -71,7 +71,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-4o-mini",
+    "model": "gemini-3-1-flash-lite-preview",
     "messages": [{"role": "user", "content": "Write a haiku about data"}],
     "stream": true
   }'

--- a/inference-api/quickstart/image-generation.mdx
+++ b/inference-api/quickstart/image-generation.mdx
@@ -15,7 +15,7 @@ Generate images from text descriptions using models like FLUX and DALL-E.
 import requests
 
 response = requests.post(
-    "https://hub.oxen.ai/api/images/generate",
+    "https://hub.oxen.ai/api/ai/images/generate",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -31,7 +31,7 @@ print("Image URL:", data["images"][0]["url"])
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/images/generate \
+curl -X POST https://hub.oxen.ai/api/ai/images/generate \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -53,7 +53,7 @@ import requests
 import base64
 
 response = requests.post(
-    "https://hub.oxen.ai/api/images/generate",
+    "https://hub.oxen.ai/api/ai/images/generate",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -75,7 +75,7 @@ print("Saved to output.png")
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/images/generate \
+curl -X POST https://hub.oxen.ai/api/ai/images/generate \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/inference-api/quickstart/image-generation.mdx
+++ b/inference-api/quickstart/image-generation.mdx
@@ -7,7 +7,7 @@ description: "Generate images from text prompts in minutes"
 
 Generate images from text descriptions using models like FLUX and DALL-E.
 
-## Minimal Example
+## Minimal Example (Synchronous)
 
 <CodeGroup>
 
@@ -83,6 +83,67 @@ curl -X POST https://hub.oxen.ai/api/ai/images/generate \
     "prompt": "A blue sphere on grey background",
     "response_format": "b64_json"
   }'
+```
+
+</CodeGroup>
+
+## Async Generation (Recommended)
+
+For longer-running image generation jobs, using the async queue avoids long-lived HTTP connections:
+
+<CodeGroup>
+
+```python Python
+import requests
+import time
+
+API_KEY = "YOUR_API_KEY"
+MODEL = "black-forest-labs-flux-2-klein-4b"
+HEADERS = {
+    "Authorization": f"Bearer {API_KEY}",
+    "Content-Type": "application/json",
+}
+
+# 1. Enqueue
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/queue",
+    headers=HEADERS,
+    json={
+        "model": MODEL,
+        "prompt": "A watercolor painting of a mountain landscape",
+    },
+)
+generations = response.json()["generations"]
+print(f"Enqueued {len(generations)} generation(s)")
+
+# 2. Poll until done
+while True:
+    status = requests.get(
+        "https://hub.oxen.ai/api/ai/queue",
+        headers=HEADERS,
+        params={"model": MODEL},
+    ).json()
+    if status["count"] == 0:
+        break
+    print(f"Still processing: {status['count']} remaining")
+    time.sleep(10)
+
+print("Done!")
+```
+
+```bash cURL
+# 1. Enqueue
+curl -X POST https://hub.oxen.ai/api/ai/queue \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "black-forest-labs-flux-2-klein-4b",
+    "prompt": "A watercolor painting of a mountain landscape"
+  }'
+
+# 2. Poll until done
+curl -H "Authorization: Bearer YOUR_API_KEY" \
+  "https://hub.oxen.ai/api/ai/queue?model=black-forest-labs-flux-2-klein-4b"
 ```
 
 </CodeGroup>

--- a/inference-api/quickstart/video-generation.mdx
+++ b/inference-api/quickstart/video-generation.mdx
@@ -5,9 +5,11 @@ description: "Generate videos from text prompts in minutes"
 
 ## Overview
 
-Generate videos from text descriptions, reference images, or existing videos. Video generation takes 1-5 minutes depending on the model and duration.
+Generate videos from text descriptions, reference images, or existing videos.
 
-## Minimal Example
+## Minimal Example (Synchronous)
+
+Note: Synchronous generation can take 5-15 minutes to complete for certain models, we recommend using the async queue and polling for long-running jobs (See Below).
 
 <CodeGroup>
 

--- a/inference-api/quickstart/video-generation.mdx
+++ b/inference-api/quickstart/video-generation.mdx
@@ -15,7 +15,7 @@ Generate videos from text descriptions, reference images, or existing videos. Vi
 import requests
 
 response = requests.post(
-    "https://hub.oxen.ai/api/videos/generate",
+    "https://hub.oxen.ai/api/ai/videos/generate",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -32,7 +32,7 @@ print("Video URL:", data["videos"][0]["url"])
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/videos/generate \
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -55,7 +55,6 @@ import requests
 import time
 
 API_KEY = "YOUR_API_KEY"
-NAMESPACE = "YOUR_USERNAME"
 MODEL = "kling-video-v2-6-pro-text-to-video"
 HEADERS = {
     "Authorization": f"Bearer {API_KEY}",
@@ -78,8 +77,9 @@ print(f"Enqueued {len(generations)} generation(s)")
 # 2. Poll until done
 while True:
     status = requests.get(
-        f"https://hub.oxen.ai/api/media/generations/status/{NAMESPACE}/{MODEL}",
+        "https://hub.oxen.ai/api/ai/queue",
         headers=HEADERS,
+        params={"model": MODEL},
     ).json()
     if status["count"] == 0:
         break
@@ -100,9 +100,9 @@ curl -X POST https://hub.oxen.ai/api/ai/queue \
     "duration": 5
   }'
 
-# 2. Poll until done (replace YOUR_USERNAME)
+# 2. Poll until done
 curl -H "Authorization: Bearer YOUR_API_KEY" \
-  "https://hub.oxen.ai/api/media/generations/status/YOUR_USERNAME/kling-video-v2-6-pro-text-to-video"
+  "https://hub.oxen.ai/api/ai/queue?model=kling-video-v2-6-pro-text-to-video"
 ```
 
 </CodeGroup>

--- a/inference-api/reference/async_queue.mdx
+++ b/inference-api/reference/async_queue.mdx
@@ -30,7 +30,7 @@ Submit an async image or video generation job.
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `model` | string | **yes** | -- | Must be an image or video model. Text-only models are rejected. |
-| `prompt` | string | **yes** | -- | Text prompt. |
+| `prompt` | string | **one of** | -- | Text prompt. Use this or `multi_prompt` for video models. |
 | `num_generations` | integer | no | `1` | How many generations to run in parallel. Range: 1-4. |
 | `target_namespace` | string | no | your username | Namespace to store results and bill to. |
 | `seed` | integer | no | -- | Random seed for reproducibility. |

--- a/inference-api/reference/async_queue.mdx
+++ b/inference-api/reference/async_queue.mdx
@@ -5,7 +5,7 @@ description: "Enqueue image and video generation jobs that process in the backgr
 
 ## Why Use the Async Queue
 
-The synchronous endpoints (`/images/generate`, `/videos/generate`) block until the result is ready. For video generation, this can be 1-10+ minutes. The async queue returns immediately with generation IDs so you can:
+The synchronous endpoints (`/ai/images/generate`, `/ai/videos/generate`) block until the result is ready. For video generation, this can be 1-10+ minutes. The async queue returns immediately with generation IDs so you can:
 
 - Generate up to 4 images or videos in parallel
 - Avoid long-lived HTTP connections
@@ -14,8 +14,8 @@ The synchronous endpoints (`/images/generate`, `/videos/generate`) block until t
 ## Workflow
 
 ```
-1. POST /ai/queue                              → Get generation IDs
-2. GET /media/generations/status/:ns/*model     → Poll until count = 0
+1. POST /ai/queue                       → Get generation IDs
+2. GET  /ai/queue  or  /ai/queue/:id    → Poll until done
 3. Results accessible via URLs in your account
 ```
 
@@ -23,15 +23,21 @@ The synchronous endpoints (`/images/generate`, `/videos/generate`) block until t
 
 ## Enqueue: POST /api/ai/queue
 
+Submit an async image or video generation job.
+
 ### Request Parameters
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `model` | string | **yes** | -- | Must be an image or video model. Text-only models are rejected. |
-| `prompt` | string | no | -- | Text prompt. |
+| `prompt` | string | **yes** | -- | Text prompt. |
 | `num_generations` | integer | no | `1` | How many generations to run in parallel. Range: 1-4. |
+| `target_namespace` | string | no | your username | Namespace to store results and bill to. |
+| `seed` | integer | no | -- | Random seed for reproducibility. |
+| `aspect_ratio` | string | no | -- | Aspect ratio (e.g. `"16:9"`, `"1:1"`). |
+| `duration` | integer | no | -- | Video duration in seconds. |
 
-All other model-specific parameters are passed through (e.g. `multi_prompt`, `duration`, `aspect_ratio`, `input_image`, `generate_audio`, `seed`, `response_format`, `target_namespace`, etc.).
+All other model-specific parameters are passed through (e.g. `multi_prompt`, `input_image`, `generate_audio`, `response_format`, etc.).
 
 ### Response
 
@@ -51,53 +57,63 @@ The API validates at enqueue time that:
 - `num_generations` is 1-4
 - The user is authenticated with sufficient credits
 
-Model-specific parameter validation (prompt content, duration ranges, aspect ratio values) happens **when the generation runs**, not at enqueue time. If a parameter is invalid, the generation fails silently (it disappears from the status list without producing a result). To validate parameters and get immediate error feedback, use `/images/generate` or `/videos/generate` instead.
+Model-specific parameter validation (prompt content, duration ranges, aspect ratio values) happens **when the generation runs**, not at enqueue time. If a parameter is invalid, the generation fails silently (it disappears from the queue without producing a result). To validate parameters and get immediate error feedback, use `/ai/images/generate` or `/ai/videos/generate` instead.
 
 ---
 
-## Poll Status: GET /api/media/generations/status/:namespace/\*model_name
+## List Generations: GET /api/ai/queue
 
-Check the status of queued generations for a specific model.
+Lists all in-progress generations. Only actively-processing generations are returned; completed, failed, or cancelled generations are not retained.
 
-- `:namespace`: Your username (e.g. `myuser`)
-- `*model_name`: The model name used to enqueue (e.g. `kling-video-o3-pro-reference-to-video`)
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `namespace` | string | no | Namespace to query. Defaults to the authenticated user. |
+| `model` | string | no | Filter by model name. |
 
 ### Response (jobs in progress)
 
 ```json
 {
-  "status": "success",
-  "count": 1,
+  "count": 2,
   "generations": [
     {
-      "generation_id": "7cf9b23a-...",
+      "generation_id": "7cf9b23a-1234-5678-9abc-def012345678",
       "model": "kling-video-o3-pro-reference-to-video",
-      "model_name": "kling-video-o3-pro-reference-to-video",
+      "prompt": "An astronaut walking on Mars",
+      "media_type": "video",
       "enqueued_at": 1775091431,
-      "multi_prompt": [{"duration": 10, "prompt": "An astronaut walking on Mars"}],
-      "aspect_ratio": "16:9"
+      "aspect_ratio": "16:9",
+      "duration": 10
+    },
+    {
+      "generation_id": "bb8f5eb7-361e-4e13-ab73-67457bc8057e",
+      "model": "black-forest-labs-flux-2-klein-4b",
+      "prompt": "Abstract geometric pattern in blue and gold",
+      "media_type": "image",
+      "enqueued_at": 1775091440
     }
   ]
 }
 ```
 
-The response echoes back the parameters you submitted along with metadata:
-
 | Field | Always Present | Description |
 |---|---|---|
+| `count` | yes | Number of in-progress generations |
 | `generation_id` | yes | Unique ID for this generation |
 | `model` | yes | Model name |
-| `model_name` | yes | Same as `model` |
+| `prompt` | yes | Text prompt |
+| `media_type` | yes | `"image"` or `"video"` |
 | `enqueued_at` | yes | Unix timestamp when the job was enqueued |
-| `prompt` | if submitted | Your text prompt |
-| `multi_prompt` | if submitted | Your multi-shot prompts |
-| other params | if submitted | Any other parameters you passed |
+| `seed` | if submitted | Random seed |
+| `aspect_ratio` | if submitted | Aspect ratio |
+| `duration` | if submitted | Video duration |
 
 ### Response (all jobs complete)
 
 ```json
 {
-  "status": "success",
   "count": 0,
   "generations": []
 }
@@ -105,7 +121,7 @@ The response echoes back the parameters you submitted along with metadata:
 
 ### How Completion Works
 
-When a generation finishes, it is removed from the status list. There is no "completed" status. Generations are either in the list (still processing) or gone (done). Poll until `count` reaches 0.
+When a generation finishes, it is removed from the queue. There is no "completed" status on this endpoint. Generations are either in the list (still processing) or gone (done). Poll until `count` reaches 0.
 
 ### Polling Strategy
 
@@ -115,9 +131,55 @@ When a generation finishes, it is removed from the status list. There is no "com
 
 ---
 
-## Cancel: DELETE /api/media/generations/:namespace/:generation_id
+## Get Generation: GET /api/ai/queue/:generation_id
 
-Cancel a queued or in-progress generation.
+Retrieves metadata for a single in-progress generation.
+
+### Path Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `generation_id` | string (UUID) | **yes** | The generation ID returned by the enqueue endpoint. |
+
+### Response (in progress)
+
+```json
+{
+  "generation_id": "7cf9b23a-1234-5678-9abc-def012345678",
+  "model": "kling-video-o3-pro-reference-to-video",
+  "prompt": "An astronaut walking on Mars",
+  "media_type": "video",
+  "enqueued_at": 1775091431,
+  "aspect_ratio": "16:9",
+  "duration": 10
+}
+```
+
+### Response (completed or not found)
+
+Returns 404 when the generation has reached a terminal state (completed, failed, cancelled, or expired after 24h):
+
+```json
+{
+  "error": {
+    "type": "resource_not_found",
+    "title": "The requested resource could not be found"
+  },
+  "status": "error"
+}
+```
+
+---
+
+## Cancel Generation: DELETE /api/ai/queue/:generation_id
+
+Cancels a queued or in-progress generation.
+
+### Path Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `generation_id` | string (UUID) | **yes** | The generation ID to cancel. |
 
 ### Response (success)
 
@@ -142,7 +204,7 @@ Returns 404:
 }
 ```
 
-You can only cancel generations that are still processing. Once a generation completes and leaves the status list, the DELETE endpoint returns 404.
+You can only cancel generations that are still processing. Once a generation completes and leaves the queue, the DELETE endpoint returns 404.
 
 ---
 
@@ -157,8 +219,6 @@ import requests
 import time
 
 API_KEY = "YOUR_API_KEY"
-NAMESPACE = "YOUR_USERNAME"
-MODEL = "black-forest-labs-flux-2-klein-4b"
 HEADERS = {
     "Authorization": f"Bearer {API_KEY}",
     "Content-Type": "application/json",
@@ -169,18 +229,20 @@ response = requests.post(
     "https://hub.oxen.ai/api/ai/queue",
     headers=HEADERS,
     json={
-        "model": MODEL,
+        "model": "black-forest-labs-flux-2-klein-4b",
         "prompt": "Abstract geometric pattern in blue and gold",
         "num_generations": 4,
     },
 )
-print(f"Enqueued: {response.json()}")
+generations = response.json()["generations"]
+print(f"Enqueued {len(generations)} generations")
 
 # Poll until done
 while True:
     status = requests.get(
-        f"https://hub.oxen.ai/api/media/generations/status/{NAMESPACE}/{MODEL}",
+        "https://hub.oxen.ai/api/ai/queue",
         headers=HEADERS,
+        params={"model": "black-forest-labs-flux-2-klein-4b"},
     ).json()
     print(f"Remaining: {status['count']}")
     if status["count"] == 0:
@@ -204,7 +266,7 @@ curl -s -X POST https://hub.oxen.ai/api/ai/queue \
 # Poll until done
 while true; do
   STATUS=$(curl -s -H "Authorization: Bearer $OXEN_API_KEY" \
-    "https://hub.oxen.ai/api/media/generations/status/myuser/black-forest-labs-flux-2-klein-4b")
+    "https://hub.oxen.ai/api/ai/queue?model=black-forest-labs-flux-2-klein-4b")
   COUNT=$(echo "$STATUS" | python3 -c "import json,sys; print(json.load(sys.stdin)['count'])")
   echo "Remaining: $COUNT"
   [ "$COUNT" -eq 0 ] && break
@@ -258,6 +320,44 @@ curl -X POST https://hub.oxen.ai/api/ai/queue \
 
 </CodeGroup>
 
+### Poll a single generation by ID
+
+<CodeGroup>
+
+```python Python
+import requests
+import time
+
+API_KEY = "YOUR_API_KEY"
+HEADERS = {"Authorization": f"Bearer {API_KEY}"}
+
+# After enqueuing, grab a generation ID
+generation_id = "bb8f5eb7-361e-4e13-ab73-67457bc8057e"
+
+while True:
+    resp = requests.get(
+        f"https://hub.oxen.ai/api/ai/queue/{generation_id}",
+        headers=HEADERS,
+    )
+    if resp.status_code == 404:
+        print("Generation complete (or cancelled/expired)")
+        break
+    print(f"Still processing: {resp.json()['model']}")
+    time.sleep(10)
+```
+
+```bash cURL
+# Check a specific generation
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/queue/bb8f5eb7-361e-4e13-ab73-67457bc8057e"
+
+# Cancel a generation
+curl -X DELETE -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/queue/bb8f5eb7-361e-4e13-ab73-67457bc8057e"
+```
+
+</CodeGroup>
+
 ## Errors
 
 | Condition | Error |
@@ -265,4 +365,4 @@ curl -X POST https://hub.oxen.ai/api/ai/queue \
 | `num_generations` out of range | `"num_generations must be an integer between 1 and 4"` |
 | Model not found | `"Model not found: <name>"` |
 | Text-only model | `":unsupported_media_type"` |
-| 404 on DELETE | Generation already completed or doesn't exist |
+| 404 on GET/DELETE | Generation completed, cancelled, expired, or doesn't exist |

--- a/inference-api/reference/chat_completions.mdx
+++ b/inference-api/reference/chat_completions.mdx
@@ -119,7 +119,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
       "index": 0,
       "message": {
         "role": "assistant",
-        "content": "Hello, how are?"
+        "content": "Hello, how are you?"
       },
       "finish_reason": "stop"
     }
@@ -254,6 +254,7 @@ When the model uses a tool, `finish_reason` is `"tool_calls"`:
       "role": "assistant",
       "tool_calls": [{
         "id": "call_GRNwPXnbuQW4Sa3QNB3FYkYw",
+        "index": 0,
         "type": "function",
         "function": {
           "name": "get_weather",

--- a/inference-api/reference/chat_completions.mdx
+++ b/inference-api/reference/chat_completions.mdx
@@ -6,7 +6,7 @@ description: "Generate text responses from language models with support for stre
 ## Endpoint
 
 ```
-POST /api/chat/completions
+POST /api/ai/chat/completions
 ```
 
 Compatible with the OpenAI chat completions format. Supports streaming, multimodal input (images and video), tool calling, and structured output.
@@ -78,7 +78,7 @@ Image and video URLs must be publicly accessible.
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://hub.oxen.ai/api",
+    base_url="https://hub.oxen.ai/api/ai",
     api_key="YOUR_API_KEY",
 )
 
@@ -93,7 +93,7 @@ print(response.choices[0].message.content)
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -140,7 +140,7 @@ curl -X POST https://hub.oxen.ai/api/chat/completions \
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://hub.oxen.ai/api",
+    base_url="https://hub.oxen.ai/api/ai",
     api_key="YOUR_API_KEY",
 )
 
@@ -158,7 +158,7 @@ print()
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -188,7 +188,7 @@ data: [DONE]
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://hub.oxen.ai/api",
+    base_url="https://hub.oxen.ai/api/ai",
     api_key="YOUR_API_KEY",
 )
 
@@ -217,7 +217,7 @@ print(f"{tool_call.function.name}({tool_call.function.arguments})")
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -273,7 +273,7 @@ When the model uses a tool, `finish_reason` is `"tool_calls"`:
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://hub.oxen.ai/api",
+    base_url="https://hub.oxen.ai/api/ai",
     api_key="YOUR_API_KEY",
 )
 
@@ -288,7 +288,7 @@ print(response.choices[0].message.content)
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/chat/completions \
+curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/inference-api/reference/chat_completions.mdx
+++ b/inference-api/reference/chat_completions.mdx
@@ -15,7 +15,7 @@ Compatible with the OpenAI chat completions format. Supports streaming, multimod
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `model` | string | **yes** | -- | Model name (e.g. `gpt-4o-mini`, `claude-sonnet-4-6`, `gpt-4-1-nano-2025-04-14`) |
+| `model` | string | **yes** | -- | Model name (e.g. `claude-sonnet-4-6`, `gpt-5-4-2026-03-05`, `gemini-3-1-flash-lite-preview`) |
 | `messages` | array | **yes** | -- | Array of message objects. Must not be empty. |
 | `stream` | boolean | no | `false` | Stream the response as server-sent events. |
 | `max_tokens` | integer | no | varies | Maximum tokens in the response. |
@@ -26,7 +26,7 @@ Compatible with the OpenAI chat completions format. Supports streaming, multimod
 | `tools` | array | no | -- | Tool/function definitions for tool calling. |
 | `tool_choice` | string/object | no | -- | Control tool selection behavior. |
 | `parallel_tool_calls` | boolean | no | -- | Allow parallel tool calls. |
-| `response_format` | object | no | -- | Constrain response format (e.g. `{"type": "json_object"}`). |
+| `response_format` | object | no | -- | Constrain response format (e.g. `{"type": "json_object"}`). Support varies by provider. |
 
 ## Message Format
 
@@ -83,7 +83,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="gpt-4-1-nano-2025-04-14",
+    model="claude-sonnet-4-6",
     messages=[{"role": "user", "content": "Say hello in exactly 3 words."}],
     max_tokens=50,
     temperature=0.1,
@@ -97,7 +97,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-4-1-nano-2025-04-14",
+    "model": "claude-sonnet-4-6",
     "messages": [{"role": "user", "content": "Say hello in exactly 3 words."}],
     "max_tokens": 50,
     "temperature": 0.1
@@ -113,7 +113,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   "id": "chatcmpl-97eab7db-fe67-4b29-900c-ed5260c654d4",
   "object": "chat.completion",
   "created": 1775090332,
-  "model": "gpt-4-1-nano-2025-04-14",
+  "model": "claude-sonnet-4-6",
   "choices": [
     {
       "index": 0,
@@ -145,7 +145,7 @@ client = OpenAI(
 )
 
 stream = client.chat.completions.create(
-    model="gpt-4-1-nano-2025-04-14",
+    model="gemini-3-1-flash-lite-preview",
     messages=[{"role": "user", "content": "Say hello"}],
     stream=True,
 )
@@ -162,7 +162,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-4-1-nano-2025-04-14",
+    "model": "gemini-3-1-flash-lite-preview",
     "messages": [{"role": "user", "content": "Say hello"}],
     "stream": true
   }'
@@ -173,7 +173,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
 Returns server-sent events. Each chunk has a `delta` instead of a full `message`:
 
 ```
-data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null,"index":0}],"created":1775090334,"id":"chatcmpl-...","model":"gpt-4-1-nano-2025-04-14","object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null,"index":0}],"created":1775090334,"id":"chatcmpl-...","model":"gemini-3-1-flash-lite-preview","object":"chat.completion.chunk"}
 
 data: {"choices":[{"delta":{"content":" there"},"finish_reason":null,"index":0}],...}
 
@@ -193,7 +193,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="gpt-4-1-nano-2025-04-14",
+    model="gpt-5-4-2026-03-05",
     messages=[
         {"role": "system", "content": "Use tools when appropriate."},
         {"role": "user", "content": "What is the weather in San Francisco?"},
@@ -221,7 +221,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-4-1-nano-2025-04-14",
+    "model": "gpt-5-4-2026-03-05",
     "messages": [
       {"role": "system", "content": "Use tools when appropriate."},
       {"role": "user", "content": "What is the weather in San Francisco?"}
@@ -278,7 +278,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="gpt-4o-mini",
+    model="gpt-5-4-2026-03-05",
     messages=[{"role": "user", "content": "List 3 colors as a JSON array"}],
     response_format={"type": "json_object"},
     max_tokens=100,
@@ -292,7 +292,7 @@ curl -X POST https://hub.oxen.ai/api/ai/chat/completions \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-4o-mini",
+    "model": "gpt-5-4-2026-03-05",
     "messages": [{"role": "user", "content": "List 3 colors as a JSON array"}],
     "response_format": {"type": "json_object"},
     "max_tokens": 100

--- a/inference-api/reference/image_editing.mdx
+++ b/inference-api/reference/image_editing.mdx
@@ -6,7 +6,7 @@ description: "Edit images using text prompts"
 ## Endpoint
 
 ```
-POST /api/images/edit
+POST /api/ai/images/edit
 ```
 
 Edit an existing image using a text prompt. The request blocks until the edited image is ready.
@@ -31,7 +31,7 @@ Edit an existing image using a text prompt. The request blocks until the edited 
 import requests
 
 response = requests.post(
-    "https://hub.oxen.ai/api/images/edit",
+    "https://hub.oxen.ai/api/ai/images/edit",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -48,7 +48,7 @@ print("Image URL:", data["images"][0]["url"])
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/images/edit \
+curl -X POST https://hub.oxen.ai/api/ai/images/edit \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -62,7 +62,7 @@ curl -X POST https://hub.oxen.ai/api/images/edit \
 
 ### Response
 
-Same format as `/images/generate`:
+Same format as `/ai/images/generate`:
 
 ```json
 {

--- a/inference-api/reference/image_generation.mdx
+++ b/inference-api/reference/image_generation.mdx
@@ -6,7 +6,7 @@ description: "Generate images from text prompts"
 ## Endpoint
 
 ```
-POST /api/images/generate
+POST /api/ai/images/generate
 ```
 
 Generates images synchronously. The request blocks until the image is ready (typically 5-30 seconds depending on the model).
@@ -23,7 +23,7 @@ Generates images synchronously. The request blocks until the image is ready (typ
 | `num_inference_steps` | integer | no | -- | Number of denoising steps. |
 | `seed` | integer | no | -- | Reproducibility seed. |
 
-Available parameters vary by model. Use the model detail endpoint (`GET /api/evaluations/models/:id`) to see the `json_request_schema` for model-specific parameters.
+Available parameters vary by model. Use the [model detail endpoint](/inference-api/reference/models#retrieve-model) (`GET /api/ai/models/:id`) to see the `request_schema` for model-specific parameters.
 
 ## Examples
 
@@ -35,7 +35,7 @@ Available parameters vary by model. Use the model detail endpoint (`GET /api/eva
 import requests
 
 response = requests.post(
-    "https://hub.oxen.ai/api/images/generate",
+    "https://hub.oxen.ai/api/ai/images/generate",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -53,7 +53,7 @@ print("Image URL:", data["images"][0]["url"])
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/images/generate \
+curl -X POST https://hub.oxen.ai/api/ai/images/generate \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/inference-api/reference/image_generation.mdx
+++ b/inference-api/reference/image_generation.mdx
@@ -23,7 +23,7 @@ Generates images synchronously. The request blocks until the image is ready (typ
 | `num_inference_steps` | integer | no | -- | Number of denoising steps. |
 | `seed` | integer | no | -- | Reproducibility seed. |
 
-Available parameters vary by model. Use the [model detail endpoint](/inference-api/reference/models#retrieve-model) (`GET /api/ai/models/:id`) to see the `request_schema` for model-specific parameters.
+Available parameters vary by model. Use the [model detail endpoint](/inference-api/reference/models/overview#retrieve-model) (`GET /api/ai/models/:id`) to see the `request_schema` for model-specific parameters.
 
 ## Examples
 

--- a/inference-api/reference/image_generation.mdx
+++ b/inference-api/reference/image_generation.mdx
@@ -19,7 +19,7 @@ Generates images synchronously. The request blocks until the image is ready (typ
 | `prompt` | string | **yes** | -- | Text description of the image to generate. |
 | `response_format` | string | no | `"url"` | `"url"` returns a hosted URL. `"b64_json"` returns base64-encoded image bytes inline. |
 | `target_namespace` | string | no | current user | Namespace to save results and bill to. Can be an organization name. |
-| `image_size` | string or object | no | -- | Size preset (e.g. `square_hd`, `portrait_4_3`) or `{"width": 1024, "height": 1024}`. |
+| `aspect_ratio` | string | no | -- | Aspect ratio (e.g. `"1:1"`, `"16:9"`, `"9:16"`, `"4:3"`, `"3:4"`). |
 | `num_inference_steps` | integer | no | -- | Number of denoising steps. |
 | `seed` | integer | no | -- | Reproducibility seed. |
 
@@ -43,7 +43,7 @@ response = requests.post(
     json={
         "model": "black-forest-labs-flux-2-klein-4b",
         "prompt": "A red cube on a white background",
-        "image_size": "square_hd",
+        "aspect_ratio": "1:1",
         "seed": 42,
     },
 )
@@ -59,7 +59,7 @@ curl -X POST https://hub.oxen.ai/api/ai/images/generate \
   -d '{
     "model": "black-forest-labs-flux-2-klein-4b",
     "prompt": "A red cube on a white background",
-    "image_size": "square_hd",
+    "aspect_ratio": "1:1",
     "seed": 42
   }'
 ```

--- a/inference-api/reference/models.mdx
+++ b/inference-api/reference/models.mdx
@@ -25,13 +25,13 @@ Lists all available models. OpenAI-compatible.
   "object": "list",
   "data": [
     {
-      "id": "gpt-4o-mini",
+      "id": "claude-sonnet-4-6",
       "object": "model",
-      "created": 1720000000,
+      "created": 1750000000,
       "owned_by": "oxen",
-      "display_name": "GPT-4o Mini",
-      "description": "Fast, affordable small model for lightweight tasks",
-      "summary": "Fast and affordable small model",
+      "display_name": "Claude Sonnet 4.6",
+      "description": "Anthropic's balanced model for a wide range of tasks",
+      "summary": "Balanced performance and speed",
       "model_type": "base",
       "endpoint": "/chat/completions",
       "capabilities": {
@@ -53,12 +53,12 @@ Lists all available models. OpenAI-compatible.
       },
       "deployments": [],
       "developer": {
-        "name": "OpenAI",
+        "name": "Anthropic",
         "logo": "https://..."
       },
       "source_model": null,
       "image_url": null,
-      "released_at": "2024-07-18T00:00:00Z",
+      "released_at": "2025-06-19T00:00:00Z",
       "request_schema": null
     }
   ]
@@ -147,7 +147,7 @@ Retrieves a model by name. Returns the full model object including the `request_
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `id` | string | **yes** | Model name (e.g. `gpt-4o-mini`, `flux-2-dev`) |
+| `id` | string | **yes** | Model name (e.g. `claude-sonnet-4-6`, `flux-2-dev`) |
 
 ### Query Parameters
 
@@ -273,7 +273,7 @@ Every endpoint above returns one or more model objects with this schema:
 
 | Field | Type | Description |
 |---|---|---|
-| `id` | string | Model identifier used in API calls (e.g. `gpt-4o-mini`) |
+| `id` | string | Model identifier used in API calls (e.g. `claude-sonnet-4-6`) |
 | `object` | string | Always `"model"` |
 | `created` | integer | Unix timestamp when the model was registered |
 | `owned_by` | string | `"oxen"` for base models, owner namespace for custom models |

--- a/inference-api/reference/models.mdx
+++ b/inference-api/reference/models.mdx
@@ -1,0 +1,314 @@
+---
+title: "Models"
+description: "List, search, and manage AI models available for inference and fine-tuning"
+---
+
+## List Models
+
+```
+GET /api/ai/models
+```
+
+Lists all available models. OpenAI-compatible.
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `developer_name` | string | no | Filter by developer (e.g. `openai`, `anthropic`, `google`) |
+| `action` | string | no | Filter by fine-tuning action type |
+
+### Response
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "gpt-4o-mini",
+      "object": "model",
+      "created": 1720000000,
+      "owned_by": "oxen",
+      "display_name": "GPT-4o Mini",
+      "description": "Fast, affordable small model for lightweight tasks",
+      "summary": "Fast and affordable small model",
+      "model_type": "base",
+      "endpoint": "/chat/completions",
+      "capabilities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "pricing": {
+        "method": "token",
+        "input_cost_per_token": 1.5e-7,
+        "output_cost_per_token": 6.0e-7,
+        "cost_per_second": null,
+        "cost_per_image": null,
+        "cost_per_second_high_res": null,
+        "cost_per_second_with_audio": null
+      },
+      "fine_tuning": {
+        "actions": ["text_generation", "text_chat_messages"],
+        "cost_per_second": 0.001
+      },
+      "deployments": [],
+      "developer": {
+        "name": "OpenAI",
+        "logo": "https://..."
+      },
+      "source_model": null,
+      "image_url": null,
+      "released_at": "2024-07-18T00:00:00Z",
+      "request_schema": null
+    }
+  ]
+}
+```
+
+### Examples
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://hub.oxen.ai/api/ai/models",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+)
+
+for model in response.json()["data"]:
+    print(f"{model['id']} ({model['endpoint']})")
+```
+
+```bash cURL
+# All models
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/models"
+
+# Filter by developer
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/models?developer_name=openai"
+```
+
+</CodeGroup>
+
+---
+
+## Search Models
+
+```
+GET /api/ai/models/search
+```
+
+Search models by name.
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `search` | string | **yes** | Search query |
+
+### Examples
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://hub.oxen.ai/api/ai/models/search",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    params={"search": "kling"},
+)
+
+for model in response.json()["data"]:
+    print(f"{model['id']} - {model['display_name']}")
+```
+
+```bash cURL
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/models/search?search=kling"
+```
+
+</CodeGroup>
+
+---
+
+## Retrieve Model
+
+```
+GET /api/ai/models/:id
+```
+
+Retrieves a model by name. Returns the full model object including the `request_schema` describing model-specific parameters.
+
+### Path Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | **yes** | Model name (e.g. `gpt-4o-mini`, `flux-2-dev`) |
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `deployment_status` | string | no | Pass `"live"` to refresh deployment status from provider before responding |
+
+### Examples
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://hub.oxen.ai/api/ai/models/kling-video-o3-pro-reference-to-video",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+)
+
+model = response.json()
+print(f"Endpoint: {model['endpoint']}")
+print(f"Pricing: {model['pricing']}")
+
+# Get the model's parameter schema
+if model.get("request_schema"):
+    print(f"Parameters: {model['request_schema']}")
+```
+
+```bash cURL
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/models/kling-video-o3-pro-reference-to-video"
+
+# With live deployment status refresh
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/models/my-custom-model?deployment_status=live"
+```
+
+</CodeGroup>
+
+---
+
+## Activate Model
+
+```
+POST /api/ai/models/:id/activate
+```
+
+Activates an inactive custom model deployment. Base models are always active and do not need activation.
+
+### Path Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | **yes** | Model name |
+
+### Examples
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/models/my-custom-model/activate",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+)
+
+model = response.json()
+print(f"Status: {model['deployments'][0]['status']}")
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/models/my-custom-model/activate \
+  -H "Authorization: Bearer $OXEN_API_KEY"
+```
+
+</CodeGroup>
+
+---
+
+## Deactivate Model
+
+```
+POST /api/ai/models/:id/deactivate
+```
+
+Deactivates an active custom model deployment to stop billing.
+
+### Path Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | **yes** | Model name |
+
+### Examples
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/models/my-custom-model/deactivate",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+)
+
+model = response.json()
+print(f"Status: {model['deployments'][0]['status']}")
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/models/my-custom-model/deactivate \
+  -H "Authorization: Bearer $OXEN_API_KEY"
+```
+
+</CodeGroup>
+
+---
+
+## Model Object
+
+Every endpoint above returns one or more model objects with this schema:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Model identifier used in API calls (e.g. `gpt-4o-mini`) |
+| `object` | string | Always `"model"` |
+| `created` | integer | Unix timestamp when the model was registered |
+| `owned_by` | string | `"oxen"` for base models, owner namespace for custom models |
+| `display_name` | string | Human-readable name |
+| `description` | string/null | Full description |
+| `summary` | string/null | Brief summary |
+| `model_type` | string | `"base"` or `"custom"` |
+| `endpoint` | string | API endpoint to call: `"/chat/completions"`, `"/images/generate"`, or `"/videos/generate"` |
+| `capabilities` | object | `{ "input": ["text", ...], "output": ["text", ...] }` — supported input/output modalities |
+| `pricing` | object | See [Pricing](#pricing) below |
+| `fine_tuning` | object/null | `{ "actions": [...], "cost_per_second": number }` or `null` if not fine-tuneable |
+| `deployments` | array | `[{ "status": "active" | "inactive" | "deploying" | "deactivating" | "error" | "unknown" }]`. Empty for base models. |
+| `developer` | object/null | `{ "name": string, "logo": string/null }` |
+| `source_model` | string/null | Base model this was fine-tuned from |
+| `image_url` | string/null | Image asset URL |
+| `released_at` | string/null | Release timestamp |
+| `request_schema` | object/null | JSON Schema describing model-specific request parameters |
+
+### Pricing
+
+The `pricing` object describes how the model is billed:
+
+| Field | Type | Description |
+|---|---|---|
+| `method` | string | `"token"`, `"time"`, `"per_image"`, or `"per_video_output_second"` |
+| `input_cost_per_token` | number/null | Cost per input token (token-based models) |
+| `output_cost_per_token` | number/null | Cost per output token (token-based models) |
+| `cost_per_second` | number/null | Cost per second (time-based models) |
+| `cost_per_image` | number/null | Fixed cost per image (image generation models) |
+| `cost_per_second_high_res` | number/null | High-resolution video cost per second |
+| `cost_per_second_with_audio` | number/null | Video with audio cost per second |
+
+## Errors
+
+| Condition | Status | Error |
+|---|---|---|
+| Model not found | 404 | `"Model not found: <name>"` |
+| Not authenticated | 401 | `"unauthenticated"` |

--- a/inference-api/reference/models/kling_o3_pro_reference_to_video.mdx
+++ b/inference-api/reference/models/kling_o3_pro_reference_to_video.mdx
@@ -12,7 +12,7 @@ Transforms reference images into dynamic video sequences. Preserves identity, la
 ## Endpoint
 
 ```
-POST /api/videos/generate
+POST /api/ai/videos/generate
 ```
 
 Video generation is synchronous, the request blocks until the video is ready (typically 1-5 minutes). Billing is calculated as `total video duration x $0.224/s`. A default 5-second video costs ~$1.12.
@@ -126,7 +126,7 @@ Maximum 4 total images across all elements and `input_image` references.
 import requests
 
 response = requests.post(
-    "https://hub.oxen.ai/api/videos/generate",
+    "https://hub.oxen.ai/api/ai/videos/generate",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -142,7 +142,7 @@ print("Video URL:", data["videos"][0]["url"])
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/videos/generate \
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -161,7 +161,7 @@ curl -X POST https://hub.oxen.ai/api/videos/generate \
 import requests
 
 response = requests.post(
-    "https://hub.oxen.ai/api/videos/generate",
+    "https://hub.oxen.ai/api/ai/videos/generate",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -178,7 +178,7 @@ print("Video URL:", data["videos"][0]["url"])
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/videos/generate \
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -198,7 +198,7 @@ curl -X POST https://hub.oxen.ai/api/videos/generate \
 import requests
 
 response = requests.post(
-    "https://hub.oxen.ai/api/videos/generate",
+    "https://hub.oxen.ai/api/ai/videos/generate",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -218,7 +218,7 @@ print("Video URL:", data["videos"][0]["url"])
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/videos/generate \
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -241,7 +241,7 @@ curl -X POST https://hub.oxen.ai/api/videos/generate \
 import requests
 
 response = requests.post(
-    "https://hub.oxen.ai/api/videos/generate",
+    "https://hub.oxen.ai/api/ai/videos/generate",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -269,7 +269,7 @@ print("Video URL:", data["videos"][0]["url"])
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/videos/generate \
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -374,8 +374,9 @@ curl -X POST https://hub.oxen.ai/api/ai/queue \
 import requests
 
 response = requests.get(
-    "https://hub.oxen.ai/api/media/generations/status/YOUR_USERNAME/kling-video-o3-pro-reference-to-video",
+    "https://hub.oxen.ai/api/ai/queue",
     headers={"Authorization": "Bearer YOUR_API_KEY"},
+    params={"model": "kling-video-o3-pro-reference-to-video"},
 )
 
 status = response.json()
@@ -384,7 +385,7 @@ print(f"Remaining: {status['count']}")
 
 ```bash cURL
 curl -H "Authorization: Bearer $OXEN_API_KEY" \
-  "https://hub.oxen.ai/api/media/generations/status/YOUR_USERNAME/kling-video-o3-pro-reference-to-video"
+  "https://hub.oxen.ai/api/ai/queue?model=kling-video-o3-pro-reference-to-video"
 ```
 
 </CodeGroup>
@@ -398,8 +399,9 @@ When finished, the generation disappears from the list. A `count` of `0` means a
 ```python Python
 import requests
 
+generation_id = "4ef840a4-..."
 response = requests.delete(
-    "https://hub.oxen.ai/api/media/generations/YOUR_USERNAME/4ef840a4-...",
+    f"https://hub.oxen.ai/api/ai/queue/{generation_id}",
     headers={"Authorization": "Bearer YOUR_API_KEY"},
 )
 
@@ -408,7 +410,7 @@ print(response.json())
 
 ```bash cURL
 curl -X DELETE -H "Authorization: Bearer $OXEN_API_KEY" \
-  "https://hub.oxen.ai/api/media/generations/YOUR_USERNAME/4ef840a4-..."
+  "https://hub.oxen.ai/api/ai/queue/4ef840a4-..."
 ```
 
 </CodeGroup>

--- a/inference-api/reference/models/kling_o3_pro_reference_to_video.mdx
+++ b/inference-api/reference/models/kling_o3_pro_reference_to_video.mdx
@@ -15,9 +15,7 @@ Transforms reference images into dynamic video sequences. Preserves identity, la
 POST /api/ai/videos/generate
 ```
 
-Video generation is synchronous, the request blocks until the video is ready (typically 1-5 minutes). Billing is calculated as `total video duration x $0.224/s`. A default 5-second video costs ~$1.12.
-
-For fire-and-forget or batch generation, use [`/ai/queue`](/inference-api/reference/async_queue) instead.
+Video generation is synchronous, the request blocks until the video is ready (typically 1-5 minutes). It is recommended to use [`/ai/queue`](/inference-api/reference/async_queue) instead for long-running jobs, so that you don't have long running http requests.
 
 ## Request Parameters
 
@@ -419,8 +417,8 @@ curl -X DELETE -H "Authorization: Bearer $OXEN_API_KEY" \
 
 | Error | Cause | Fix |
 |---|---|---|
-| `Cannot provide both 'prompt' and 'multi_prompt'` | Sent both fields | Use one or the other |
-| `Either 'prompt' or 'multi_prompt' must be provided` | Neither sent, or empty array | Provide at least one |
+| `Getting model response error: 422 - Value error, Cannot provide both 'prompt' and 'multi_prompt'.` | Sent both fields | Use one or the other |
+| `Getting model response error: 422 - Value error, Either 'prompt' or 'multi_prompt' must be provided.` | Neither sent, or empty array | Provide at least one |
 | `Field required` | `multi_prompt` item missing `prompt` | Every shot needs a `prompt` string |
 | `duration value '2' is invalid` | Total duration < 3 seconds | Ensure total across shots >= 3 |
 | `Total shot duration (16s) exceeds maximum allowed (15s)` | Total duration > 15 seconds | Keep total at 15 seconds or less |

--- a/inference-api/reference/models/kling_o3_pro_video_to_video_edit.mdx
+++ b/inference-api/reference/models/kling_o3_pro_video_to_video_edit.mdx
@@ -1,0 +1,321 @@
+---
+title: "Kling O3 Edit: Video to Video"
+description: "Edit existing videos using text prompts with optional reference images and character elements"
+---
+
+Edit existing videos using text instructions. Describe what to change — add objects, swap characters, alter scenery — and the model re-renders the video accordingly. Supports reference images (`@Image1`, `@Image2`, …) and structured element references (`@Element1`, `@Element2`, …) for character/object consistency across the edit.
+
+**Model name:** `kling-video-o3-pro-video-to-video-edit`
+**Pricing:** $0.336/second of output video
+**Input:** video + text | **Output:** video
+
+## Endpoint
+
+```
+POST /api/ai/videos/generate
+```
+
+Video editing is synchronous — the request blocks until the edited video is ready (typically 1–5 minutes).
+
+It is recommended to use [`/ai/queue`](/inference-api/reference/async_queue) instead for long-running jobs, so that you don't have long running http requests.
+
+## Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `model` | string | **yes** | -- | `"kling-video-o3-pro-video-to-video-edit"` |
+| `prompt` | string | **yes** | -- | Text description of what to generate or how to edit the video. |
+| `input_video` | string (URI) | **yes** | -- | URL of the source video to edit. |
+| `input_image` | array of URIs | no | -- | Reference images for style/appearance. Use `@Image1`, `@Image2`, etc. in the prompt to refer to them. |
+| `elements` | array of objects | no | -- | Structured element references for characters/objects. See [elements](#elements) below. |
+| `keep_audio` | boolean | no | `false` | Whether to keep the original audio from the source video. |
+| `response_format` | string | no | `"url"` | `"url"` returns a hosted URL. `"b64_json"` returns base64-encoded video bytes inline. |
+| `target_namespace` | string | no | current user | Namespace to save results and bill to. Can be an organization name. |
+
+### elements
+
+Array of element objects for character/object reference. Use `@Element1`, `@Element2`, etc. in prompts.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `frontal_image_url` | string (URI) | **yes** | Front view of the reference object or character. |
+| `reference_image_urls` | array of URIs | no | Additional angles. Max 3 images per element. |
+
+## Examples
+
+### Basic video edit
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/videos/generate",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "kling-video-o3-pro-video-to-video-edit",
+        "prompt": "A red bird flies in and lands in-between the two birds on the wire",
+        "input_video": "https://example.com/birds-on-wire.mp4",
+    },
+)
+
+data = response.json()
+print("Video URL:", data["videos"][0]["url"])
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "kling-video-o3-pro-video-to-video-edit",
+    "prompt": "A red bird flies in and lands in-between the two birds on the wire",
+    "input_video": "https://example.com/birds-on-wire.mp4"
+  }'
+```
+
+</CodeGroup>
+
+### Edit with reference images
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/videos/generate",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "kling-video-o3-pro-video-to-video-edit",
+        "prompt": "Replace the person with @Image1 walking in the same direction",
+        "input_video": "https://example.com/street-scene.mp4",
+        "input_image": ["https://example.com/character-reference.jpg"],
+    },
+)
+
+data = response.json()
+print("Video URL:", data["videos"][0]["url"])
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "kling-video-o3-pro-video-to-video-edit",
+    "prompt": "Replace the person with @Image1 walking in the same direction",
+    "input_video": "https://example.com/street-scene.mp4",
+    "input_image": ["https://example.com/character-reference.jpg"]
+  }'
+```
+
+</CodeGroup>
+
+### Edit with elements and keep audio
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/videos/generate",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "kling-video-o3-pro-video-to-video-edit",
+        "prompt": "@Element1 replaces the main character in the scene",
+        "input_video": "https://example.com/original-scene.mp4",
+        "elements": [
+            {
+                "frontal_image_url": "https://example.com/character-front.jpg",
+                "reference_image_urls": [
+                    "https://example.com/character-side.jpg",
+                    "https://example.com/character-back.jpg",
+                ],
+            }
+        ],
+        "keep_audio": True,
+    },
+)
+
+data = response.json()
+print("Video URL:", data["videos"][0]["url"])
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "kling-video-o3-pro-video-to-video-edit",
+    "prompt": "@Element1 replaces the main character in the scene",
+    "input_video": "https://example.com/original-scene.mp4",
+    "elements": [
+      {
+        "frontal_image_url": "https://example.com/character-front.jpg",
+        "reference_image_urls": [
+          "https://example.com/character-side.jpg",
+          "https://example.com/character-back.jpg"
+        ]
+      }
+    ],
+    "keep_audio": true
+  }'
+```
+
+</CodeGroup>
+
+### Response (`response_format: "url"`)
+
+```json
+{
+  "created": 1775090723,
+  "model": "kling-video-o3-pro-video-to-video-edit",
+  "videos": [
+    {
+      "url": "https://hub.oxen.ai/api/repos/.../files/.../video.mp4?..."
+    }
+  ]
+}
+```
+
+The URL is a temporary link that expires after a period of time.
+
+### Response (`response_format: "b64_json"`)
+
+```json
+{
+  "created": 1775090723,
+  "model": "kling-video-o3-pro-video-to-video-edit",
+  "videos": [
+    {
+      "b64_json": "<base64-encoded mp4 bytes>"
+    }
+  ]
+}
+```
+
+## Using with /ai/queue
+
+Recommended for video editing. Returns immediately, processes in the background.
+
+### Enqueue
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/queue",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "kling-video-o3-pro-video-to-video-edit",
+        "prompt": "Change the background to a sunset beach",
+        "input_video": "https://example.com/my-video.mp4",
+        "num_generations": 2,
+    },
+)
+
+generations = response.json()["generations"]
+for g in generations:
+    print(f"ID: {g['generation_id']}, Status: {g['status']}")
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/queue \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "kling-video-o3-pro-video-to-video-edit",
+    "prompt": "Change the background to a sunset beach",
+    "input_video": "https://example.com/my-video.mp4",
+    "num_generations": 2
+  }'
+```
+
+</CodeGroup>
+
+### Poll
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://hub.oxen.ai/api/ai/queue",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    params={"model": "kling-video-o3-pro-video-to-video-edit"},
+)
+
+status = response.json()
+print(f"Remaining: {status['count']}")
+```
+
+```bash cURL
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/queue?model=kling-video-o3-pro-video-to-video-edit"
+```
+
+</CodeGroup>
+
+When finished, the generation disappears from the list. A `count` of `0` means all generations are complete.
+
+### Cancel
+
+<CodeGroup>
+
+```python Python
+import requests
+
+generation_id = "4ef840a4-..."
+response = requests.delete(
+    f"https://hub.oxen.ai/api/ai/queue/{generation_id}",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+)
+
+print(response.json())
+```
+
+```bash cURL
+curl -X DELETE -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/queue/4ef840a4-..."
+```
+
+</CodeGroup>
+
+## Errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Field required` | Missing `prompt` or `input_video` | Both are required |
+| `Invalid URL` | Malformed `input_video` URL | Provide a valid video URL |
+| `num_generations must be an integer between 1 and 4` | Invalid count (via `/ai/queue`) | Use 1–4 |
+
+## Other Kling Models
+
+| Model | Input | Use Case | Cost/sec |
+|---|---|---|---|
+| `kling-video-v2-6-pro-text-to-video` | Text only | Simple text-to-video | $0.070 |
+| `kling-video-v2-6-pro-image-to-video` | Image | Animate a single image | $0.070 |
+| `kling-video-o3-pro-image-to-video` | Image + text | Higher quality image animation | $0.224 |
+| `kling-video-o3-pro-reference-to-video` | Images + text | Reference-conditioned, multi-shot | $0.224 |
+| `kling-video-o3-pro-video-to-video-edit` | Video + text | Edit existing video | $0.336 |
+| `kling-video-v3-pro-motion-control` | Text + image + video | Camera/motion control | $0.168 |
+
+The O3 Pro models produce higher quality output than v2.x but cost roughly 3x more per second.

--- a/inference-api/reference/models/overview.mdx
+++ b/inference-api/reference/models/overview.mdx
@@ -40,17 +40,10 @@ Lists all available models. OpenAI-compatible.
       },
       "pricing": {
         "method": "token",
-        "input_cost_per_token": 1.5e-7,
-        "output_cost_per_token": 6.0e-7,
-        "cost_per_second": null,
-        "cost_per_image": null,
-        "cost_per_second_high_res": null,
-        "cost_per_second_with_audio": null
+        "input_cost_per_token": 3e-6,
+        "output_cost_per_token": 1.5e-5
       },
-      "fine_tuning": {
-        "actions": ["text_generation", "text_chat_messages"],
-        "cost_per_second": 0.001
-      },
+      "fine_tuning": null,
       "deployments": [],
       "developer": {
         "name": "Anthropic",

--- a/inference-api/reference/models/overview.mdx
+++ b/inference-api/reference/models/overview.mdx
@@ -282,11 +282,11 @@ Every endpoint above returns one or more model objects with this schema:
 | `summary` | string/null | Brief summary |
 | `model_type` | string | `"base"` or `"custom"` |
 | `endpoint` | string | API endpoint to call: `"/chat/completions"`, `"/images/generate"`, or `"/videos/generate"` |
-| `capabilities` | object | `{ "input": ["text", ...], "output": ["text", ...] }` — supported input/output modalities |
+| `capabilities` | object | Input/output modalities, e.g. `input: ["text", "image"]`, `output: ["text"]` |
 | `pricing` | object | See [Pricing](#pricing) below |
-| `fine_tuning` | object/null | `{ "actions": [...], "cost_per_second": number }` or `null` if not fine-tuneable |
-| `deployments` | array | `[{ "status": "active" | "inactive" | "deploying" | "deactivating" | "error" | "unknown" }]`. Empty for base models. |
-| `developer` | object/null | `{ "name": string, "logo": string/null }` |
+| `fine_tuning` | object/null | Fine-tuning config with `actions` and `cost_per_second`, or `null` if not fine-tuneable |
+| `deployments` | array | Deployment status objects. Possible statuses: `active`, `inactive`, `deploying`, `deactivating`, `error`, `unknown`. Empty for base models. |
+| `developer` | object/null | Developer info with `name` and `logo` fields |
 | `source_model` | string/null | Base model this was fine-tuned from |
 | `image_url` | string/null | Image asset URL |
 | `released_at` | string/null | Release timestamp |

--- a/inference-api/reference/models/seedance_2_reference_to_video.mdx
+++ b/inference-api/reference/models/seedance_2_reference_to_video.mdx
@@ -1,0 +1,360 @@
+---
+title: "Seedance 2.0: Reference to Video"
+description: "Generate videos from text prompts guided by reference images, videos, and audio"
+---
+
+ByteDance Seedance 2.0 reference-to-video generates video from a text prompt guided by reference images, videos, and/or audio. Reference media are addressed in the prompt as `@Image1`, `@Image2`, `@Video1`, `@Video2`, `@Audio1`, etc. Supports resolutions up to 720p, durations from 4–15 seconds, and synchronized audio generation including sound effects, ambient sounds, and lip-synced speech.
+
+**Model name:** `bytedance-seedance-2-0-reference-to-video`
+**Pricing:** $0.40/second of output video (same rate with or without audio)
+**Input:** text + image + video + audio | **Output:** video
+
+## Endpoint
+
+```
+POST /api/ai/videos/generate
+```
+
+Video generation is synchronous — the request blocks until the video is ready (typically 1–5 minutes).
+
+It is recommended to use [`/ai/queue`](/inference-api/reference/async_queue) instead for long-running jobs, so that you don't have long running http requests.
+
+## Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `model` | string | **yes** | -- | `"bytedance-seedance-2-0-reference-to-video"` |
+| `prompt` | string | **yes** | -- | Text prompt. Use `@Image1`, `@Video1`, `@Audio1`, etc. to reference input media. |
+| `input_images` | array of URIs | no | -- | Reference images (JPEG, PNG, WebP). Max 30 MB each. Up to 9. Use `@Image1`, `@Image2`, … in the prompt. |
+| `input_videos` | array of URIs | no | -- | Reference videos (MP4, MOV). Up to 3. Combined duration must be 2–15 s, total size < 50 MB. Resolution between ~480p and ~720p. Use `@Video1`, `@Video2`, … in the prompt. |
+| `input_audios` | array of URIs | no | -- | Reference audio (MP3, WAV). Up to 3 files. Combined duration ≤ 15 s. Max 15 MB each. Requires at least one reference image or video. Use `@Audio1`, `@Audio2`, … in the prompt. |
+| `resolution` | string | no | `"720p"` | `"480p"` for faster generation, `"720p"` for higher quality. |
+| `duration` | string | no | `"auto"` | Duration in seconds: `"auto"`, or `"4"` through `"15"`. |
+| `generate_audio` | boolean | no | `true` | Generate synchronized audio (sound effects, ambient sounds, lip-synced speech). Cost is the same either way. |
+| `aspect_ratio` | string | no | `"auto"` | `"auto"`, `"21:9"`, `"16:9"`, `"4:3"`, `"1:1"`, `"3:4"`, or `"9:16"`. |
+| `seed` | integer | no | -- | Random seed for reproducibility. Results may still vary slightly. |
+| `response_format` | string | no | `"url"` | `"url"` returns a hosted URL. `"b64_json"` returns base64-encoded video bytes inline. |
+| `target_namespace` | string | no | current user | Namespace to save results and bill to. Can be an organization name. |
+
+### Reference Media Limits
+
+| Modality | Max Count | Size Limit | Other Constraints |
+|---|---|---|---|
+| Images | 9 | 30 MB each | JPEG, PNG, WebP |
+| Videos | 3 | 50 MB total | MP4, MOV. Combined duration 2–15 s. Resolution ~480p to ~720p. |
+| Audio | 3 | 15 MB each | MP3, WAV. Combined duration ≤ 15 s. Requires ≥ 1 image or video. |
+
+Total files across all modalities must not exceed 12.
+
+### Duration
+
+| Value | Behavior |
+|---|---|
+| `"auto"` | Model decides based on prompt and references |
+| `"4"` – `"15"` | Fixed duration in seconds |
+
+## Examples
+
+### Text-only prompt
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/videos/generate",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "bytedance-seedance-2-0-reference-to-video",
+        "prompt": "A serene mountain lake at sunrise with mist rolling across the water",
+    },
+)
+
+data = response.json()
+print("Video URL:", data["videos"][0]["url"])
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "bytedance-seedance-2-0-reference-to-video",
+    "prompt": "A serene mountain lake at sunrise with mist rolling across the water"
+  }'
+```
+
+</CodeGroup>
+
+### With reference images
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/videos/generate",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "bytedance-seedance-2-0-reference-to-video",
+        "prompt": "@Image1 walks through a crowded market, browsing the stalls",
+        "input_images": ["https://example.com/character.jpg"],
+        "duration": "8",
+        "aspect_ratio": "16:9",
+    },
+)
+
+data = response.json()
+print("Video URL:", data["videos"][0]["url"])
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "bytedance-seedance-2-0-reference-to-video",
+    "prompt": "@Image1 walks through a crowded market, browsing the stalls",
+    "input_images": ["https://example.com/character.jpg"],
+    "duration": "8",
+    "aspect_ratio": "16:9"
+  }'
+```
+
+</CodeGroup>
+
+### With reference video and audio
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/videos/generate",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "bytedance-seedance-2-0-reference-to-video",
+        "prompt": "@Image1 dances to the rhythm of @Audio1 in the style of @Video1",
+        "input_images": ["https://example.com/dancer.jpg"],
+        "input_videos": ["https://example.com/dance-reference.mp4"],
+        "input_audios": ["https://example.com/music.mp3"],
+        "resolution": "720p",
+        "duration": "10",
+        "generate_audio": True,
+    },
+)
+
+data = response.json()
+print("Video URL:", data["videos"][0]["url"])
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "bytedance-seedance-2-0-reference-to-video",
+    "prompt": "@Image1 dances to the rhythm of @Audio1 in the style of @Video1",
+    "input_images": ["https://example.com/dancer.jpg"],
+    "input_videos": ["https://example.com/dance-reference.mp4"],
+    "input_audios": ["https://example.com/music.mp3"],
+    "resolution": "720p",
+    "duration": "10",
+    "generate_audio": true
+  }'
+```
+
+</CodeGroup>
+
+### Portrait video at 480p
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/videos/generate",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "bytedance-seedance-2-0-reference-to-video",
+        "prompt": "@Image1 speaks directly to camera, warm studio lighting",
+        "input_images": ["https://example.com/speaker.jpg"],
+        "resolution": "480p",
+        "aspect_ratio": "9:16",
+        "duration": "6",
+        "generate_audio": True,
+    },
+)
+
+data = response.json()
+print("Video URL:", data["videos"][0]["url"])
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "bytedance-seedance-2-0-reference-to-video",
+    "prompt": "@Image1 speaks directly to camera, warm studio lighting",
+    "input_images": ["https://example.com/speaker.jpg"],
+    "resolution": "480p",
+    "aspect_ratio": "9:16",
+    "duration": "6",
+    "generate_audio": true
+  }'
+```
+
+</CodeGroup>
+
+### Response (`response_format: "url"`)
+
+```json
+{
+  "created": 1775090723,
+  "model": "bytedance-seedance-2-0-reference-to-video",
+  "videos": [
+    {
+      "url": "https://hub.oxen.ai/api/repos/.../files/.../video.mp4?..."
+    }
+  ]
+}
+```
+
+The URL is a temporary link that expires after a period of time.
+
+### Response (`response_format: "b64_json"`)
+
+```json
+{
+  "created": 1775090723,
+  "model": "bytedance-seedance-2-0-reference-to-video",
+  "videos": [
+    {
+      "b64_json": "<base64-encoded mp4 bytes>"
+    }
+  ]
+}
+```
+
+## Using with /ai/queue
+
+Recommended for video generation. Returns immediately, processes in the background.
+
+### Enqueue
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/queue",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "bytedance-seedance-2-0-reference-to-video",
+        "prompt": "@Image1 waves at the camera and smiles",
+        "input_images": ["https://example.com/person.jpg"],
+        "duration": "5",
+        "num_generations": 2,
+    },
+)
+
+generations = response.json()["generations"]
+for g in generations:
+    print(f"ID: {g['generation_id']}, Status: {g['status']}")
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/queue \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "bytedance-seedance-2-0-reference-to-video",
+    "prompt": "@Image1 waves at the camera and smiles",
+    "input_images": ["https://example.com/person.jpg"],
+    "duration": "5",
+    "num_generations": 2
+  }'
+```
+
+</CodeGroup>
+
+### Poll
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://hub.oxen.ai/api/ai/queue",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    params={"model": "bytedance-seedance-2-0-reference-to-video"},
+)
+
+status = response.json()
+print(f"Remaining: {status['count']}")
+```
+
+```bash cURL
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/queue?model=bytedance-seedance-2-0-reference-to-video"
+```
+
+</CodeGroup>
+
+When finished, the generation disappears from the list. A `count` of `0` means all generations are complete.
+
+### Cancel
+
+<CodeGroup>
+
+```python Python
+import requests
+
+generation_id = "4ef840a4-..."
+response = requests.delete(
+    f"https://hub.oxen.ai/api/ai/queue/{generation_id}",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+)
+
+print(response.json())
+```
+
+```bash cURL
+curl -X DELETE -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/queue/4ef840a4-..."
+```
+
+</CodeGroup>
+
+## Errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Field required` | Missing `prompt` | Provide a text prompt |
+| `Too many input files` | Total files across images, videos, audio > 12 | Reduce the number of reference files |
+| `Audio requires at least one image or video` | `input_audios` provided without `input_images` or `input_videos` | Add at least one reference image or video |
+| `Invalid duration` | Duration not `"auto"` or `"4"`–`"15"` | Use a supported duration value |
+| `Invalid resolution` | Resolution not `"480p"` or `"720p"` | Use `"480p"` or `"720p"` |
+| `num_generations must be an integer between 1 and 4` | Invalid count (via `/ai/queue`) | Use 1–4 |

--- a/inference-api/reference/models/topaz_starlight_precise_2_5.mdx
+++ b/inference-api/reference/models/topaz_starlight_precise_2_5.mdx
@@ -1,0 +1,251 @@
+---
+title: "Topaz Starlight Precise 2.5"
+description: "Upscale and restore video to 1080p or 4K with detail-preserving temporal consistency"
+---
+
+Video restoration and upscaling model focused on preserving fine detail and temporal consistency while improving clarity. Upscales input video to 1080p, 2K, or 4K and lets you control the output frame rate (up to 60 fps).
+
+**Model name:** `topazlabs-upscale-starlight-2-5-video`
+**Pricing:** $0.0374/second at 1080p | $0.1494/second at 2K/4K
+**Input:** video | **Output:** video
+
+## Endpoint
+
+```
+POST /api/ai/videos/generate
+```
+
+Video upscaling is synchronous — the request blocks until the video is ready. Processing time depends on the input video length and target resolution.
+
+It is recommended to use [`/ai/queue`](/inference-api/reference/async_queue) instead for long-running jobs, so that you don't have long running http requests.
+
+## Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `model` | string | **yes** | -- | `"topazlabs-upscale-starlight-2-5-video"` |
+| `input_video` | string (URI) | **yes** | -- | URL of the video to upscale. |
+| `resolution` | string | no | `"4k"` | Target output resolution: `"1080p"`, `"2k"`, or `"4k"`. |
+| `target_fps` | integer | no | `24` | Target frame rate (1–60 fps). |
+| `response_format` | string | no | `"url"` | `"url"` returns a hosted URL. `"b64_json"` returns base64-encoded video bytes inline. |
+| `target_namespace` | string | no | current user | Namespace to save results and bill to. Can be an organization name. |
+
+### Resolution and Pricing
+
+| Resolution | Cost per Second |
+|---|---|
+| 1080p | $0.0374 |
+| 2K | $0.1494 |
+| 4K | $0.1494 |
+
+Higher resolutions (2K and 4K) are billed at the high-res rate.
+
+## Examples
+
+### Upscale to 4K (default)
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/videos/generate",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "topazlabs-upscale-starlight-2-5-video",
+        "input_video": "https://example.com/my-video.mp4",
+    },
+)
+
+data = response.json()
+print("Video URL:", data["videos"][0]["url"])
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "topazlabs-upscale-starlight-2-5-video",
+    "input_video": "https://example.com/my-video.mp4"
+  }'
+```
+
+</CodeGroup>
+
+### Upscale to 1080p at 60 fps
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/videos/generate",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "topazlabs-upscale-starlight-2-5-video",
+        "input_video": "https://example.com/my-video.mp4",
+        "resolution": "1080p",
+        "target_fps": 60,
+    },
+)
+
+data = response.json()
+print("Video URL:", data["videos"][0]["url"])
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "topazlabs-upscale-starlight-2-5-video",
+    "input_video": "https://example.com/my-video.mp4",
+    "resolution": "1080p",
+    "target_fps": 60
+  }'
+```
+
+</CodeGroup>
+
+### Response (`response_format: "url"`)
+
+```json
+{
+  "created": 1775090723,
+  "model": "topazlabs-upscale-starlight-2-5-video",
+  "videos": [
+    {
+      "url": "https://hub.oxen.ai/api/repos/.../files/.../video.mp4?..."
+    }
+  ]
+}
+```
+
+The URL is a temporary link that expires after a period of time.
+
+### Response (`response_format: "b64_json"`)
+
+```json
+{
+  "created": 1775090723,
+  "model": "topazlabs-upscale-starlight-2-5-video",
+  "videos": [
+    {
+      "b64_json": "<base64-encoded mp4 bytes>"
+    }
+  ]
+}
+```
+
+## Using with /ai/queue
+
+Recommended for longer videos. Returns immediately, processes in the background.
+
+### Enqueue
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/queue",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "topazlabs-upscale-starlight-2-5-video",
+        "input_video": "https://example.com/my-video.mp4",
+        "resolution": "4k",
+        "target_fps": 30,
+        "num_generations": 1,
+    },
+)
+
+generations = response.json()["generations"]
+for g in generations:
+    print(f"ID: {g['generation_id']}, Status: {g['status']}")
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/queue \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "topazlabs-upscale-starlight-2-5-video",
+    "input_video": "https://example.com/my-video.mp4",
+    "resolution": "4k",
+    "target_fps": 30,
+    "num_generations": 1
+  }'
+```
+
+</CodeGroup>
+
+### Poll
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://hub.oxen.ai/api/ai/queue",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    params={"model": "topazlabs-upscale-starlight-2-5-video"},
+)
+
+status = response.json()
+print(f"Remaining: {status['count']}")
+```
+
+```bash cURL
+curl -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/queue?model=topazlabs-upscale-starlight-2-5-video"
+```
+
+</CodeGroup>
+
+When finished, the generation disappears from the list. A `count` of `0` means all generations are complete.
+
+### Cancel
+
+<CodeGroup>
+
+```python Python
+import requests
+
+generation_id = "4ef840a4-..."
+response = requests.delete(
+    f"https://hub.oxen.ai/api/ai/queue/{generation_id}",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+)
+
+print(response.json())
+```
+
+```bash cURL
+curl -X DELETE -H "Authorization: Bearer $OXEN_API_KEY" \
+  "https://hub.oxen.ai/api/ai/queue/4ef840a4-..."
+```
+
+</CodeGroup>
+
+## Errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Field required` | Missing `input_video` | Provide a video URL |
+| `Invalid resolution` | Unsupported resolution value | Use `"1080p"`, `"2k"`, or `"4k"` |
+| `target_fps must be between 1 and 60` | FPS out of range | Use a value between 1 and 60 |
+| `num_generations must be an integer between 1 and 4` | Invalid count (via `/ai/queue`) | Use 1–4 |

--- a/inference-api/reference/video_generation.mdx
+++ b/inference-api/reference/video_generation.mdx
@@ -28,7 +28,7 @@ For long-running or batch generation, consider using the [async queue](/inferenc
 | `response_format` | string | no | `"url"` | `"url"` returns a hosted URL. `"b64_json"` returns base64-encoded video bytes inline. |
 | `target_namespace` | string | no | current user | Namespace to save results and bill to. Can be an organization name. |
 
-Additional parameters vary by model. Use the [model detail endpoint](/inference-api/reference/models#retrieve-model) (`GET /api/ai/models/:id`) to see the `request_schema` for model-specific parameters.
+Additional parameters vary by model. Use the [model detail endpoint](/inference-api/reference/models/overview#retrieve-model) (`GET /api/ai/models/:id`) to see the `request_schema` for model-specific parameters.
 
 Either `prompt` or `multi_prompt` is required. Sending both returns an error:
 

--- a/inference-api/reference/video_generation.mdx
+++ b/inference-api/reference/video_generation.mdx
@@ -33,13 +33,13 @@ Additional parameters vary by model. Use the [model detail endpoint](/inference-
 Either `prompt` or `multi_prompt` is required. Sending both returns an error:
 
 ```
-"Cannot provide both 'prompt' and 'multi_prompt'."
+"Getting model response error: 422 - Value error, Cannot provide both 'prompt' and 'multi_prompt'."
 ```
 
 Sending neither returns:
 
 ```
-"Either 'prompt' or 'multi_prompt' must be provided."
+"Getting model response error: 422 - Value error, Either 'prompt' or 'multi_prompt' must be provided."
 ```
 
 ## Examples
@@ -163,6 +163,6 @@ curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
 
 | Condition | Error |
 |---|---|
-| Both `prompt` and `multi_prompt` | `"Cannot provide both 'prompt' and 'multi_prompt'."` |
-| Neither `prompt` nor `multi_prompt` | `"Either 'prompt' or 'multi_prompt' must be provided."` |
+| Both `prompt` and `multi_prompt` | `"Getting model response error: 422 - Value error, Cannot provide both 'prompt' and 'multi_prompt'."` |
+| Neither `prompt` nor `multi_prompt` | `"Getting model response error: 422 - Value error, Either 'prompt' or 'multi_prompt' must be provided."` |
 | Model not found | `"Model not found: <name>"` |

--- a/inference-api/reference/video_generation.mdx
+++ b/inference-api/reference/video_generation.mdx
@@ -6,7 +6,7 @@ description: "Generate videos from text prompts, images, or other videos"
 ## Endpoint
 
 ```
-POST /api/videos/generate
+POST /api/ai/videos/generate
 ```
 
 Generates videos synchronously. The request blocks until the video is ready, which can take 1-10+ minutes depending on the model and duration.
@@ -28,7 +28,7 @@ For long-running or batch generation, consider using the [async queue](/inferenc
 | `response_format` | string | no | `"url"` | `"url"` returns a hosted URL. `"b64_json"` returns base64-encoded video bytes inline. |
 | `target_namespace` | string | no | current user | Namespace to save results and bill to. Can be an organization name. |
 
-Additional parameters vary by model. Use the model detail endpoint (`GET /api/evaluations/models/:id`) to see the `json_request_schema` for model-specific parameters.
+Additional parameters vary by model. Use the [model detail endpoint](/inference-api/reference/models#retrieve-model) (`GET /api/ai/models/:id`) to see the `request_schema` for model-specific parameters.
 
 Either `prompt` or `multi_prompt` is required. Sending both returns an error:
 
@@ -52,7 +52,7 @@ Sending neither returns:
 import requests
 
 response = requests.post(
-    "https://hub.oxen.ai/api/videos/generate",
+    "https://hub.oxen.ai/api/ai/videos/generate",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -69,7 +69,7 @@ print("Video URL:", data["videos"][0]["url"])
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/videos/generate \
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -119,7 +119,7 @@ The URL is a temporary link that expires after a period of time.
 import requests
 
 response = requests.post(
-    "https://hub.oxen.ai/api/videos/generate",
+    "https://hub.oxen.ai/api/ai/videos/generate",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -139,7 +139,7 @@ print("Video URL:", data["videos"][0]["url"])
 ```
 
 ```bash cURL
-curl -X POST https://hub.oxen.ai/api/videos/generate \
+curl -X POST https://hub.oxen.ai/api/ai/videos/generate \
   -H "Authorization: Bearer $OXEN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/mint.json
+++ b/mint.json
@@ -182,7 +182,8 @@
                       "inference-api/reference/image_generation",
                       "inference-api/reference/image_editing",
                       "inference-api/reference/video_generation",
-                      "inference-api/reference/async_queue"
+                      "inference-api/reference/async_queue",
+                      "inference-api/reference/models"
                   ]
               },
               {

--- a/mint.json
+++ b/mint.json
@@ -183,7 +183,7 @@
                       "inference-api/reference/image_editing",
                       "inference-api/reference/video_generation",
                       "inference-api/reference/async_queue",
-                      "inference-api/reference/models"
+                      "inference-api/reference/models/overview"
                   ]
               },
               {

--- a/mint.json
+++ b/mint.json
@@ -189,7 +189,10 @@
               {
                   "group": "Model References",
                   "pages": [
-                      "inference-api/reference/models/kling_o3_pro_reference_to_video"
+                      "inference-api/reference/models/kling_o3_pro_reference_to_video",
+                      "inference-api/reference/models/kling_o3_pro_video_to_video_edit",
+                      "inference-api/reference/models/seedance_2_reference_to_video",
+                      "inference-api/reference/models/topaz_starlight_precise_2_5"
                   ]
               }
           ]


### PR DESCRIPTION
New:
* Added Models API reference with full schema
* Rewrote Queue API reference to match new schema

Structure updates:
* Updated inference api overview with new endpoint table, models section, base URL documentation
* Added Models API reference to mint.json nav

Endpoint URL updates:
* Updated OpenAI SDK base_url from `hub.oxen.ai/api` to `hub.oxen.ai/api/ai`
* Updated `/api/chat/completions` → `/api/ai/chat/completions` across all files
* Updated `/api/images/generate` → `/api/ai/images/generate` across all files
* Updated `/api/images/edit` → `/api/ai/images/edit` across all files
* Updated `/api/videos/generate` → `/api/ai/videos/generate` across all files
* Updated `/media/generations/status/*` → `/ai/queue` across all files

Other updates:
* Updated sample models to more recent models, varied by use case
* Fixed example inconsistencies (model attribution, tool call IDs)