### PR TITLE
Fix CoQA dataset link to use .jsonl instead of .parquet

### DIFF
--- a/examples/fine-tuning/chat_completions.mdx
+++ b/examples/fine-tuning/chat_completions.mdx
@@ -7,7 +7,7 @@ This tutorial will show you how to fine-tune an LLM on a history of messages. If
 
 ## Upload Your Dataset
 
-For this example, we are teaching the model to answer questions based on context that is supplied in the system prompt. You can follow along with the [Tutorials/CoQA](https://www.oxen.ai/Tutorials/CoQA/file/main/train_coqa.parquet) dataset containing over 7,000 rows of chat messages. Each row of the dataset contains a conversation between a user and an assistant.
+For this example, we are teaching the model to answer questions based on context that is supplied in the system prompt. You can follow along with the [Tutorials/CoQA](https://www.oxen.ai/Tutorials/CoQA/file/main/train_coqa.jsonl) dataset containing over 7,000 rows of chat messages. Each row of the dataset contains a conversation between a user and an assistant.
 
 <img 
   src="/images/fine_tuning/chat-completions/dataset.png" 


### PR DESCRIPTION
## Summary
- The CoQA dataset link in `examples/fine-tuning/chat_completions.mdx` pointed to `train_coqa.parquet`, but the actual file in the Tutorials/CoQA repo is `train_coqa.jsonl`.

## Test plan
- [ ] Verify the updated link resolves on oxen.ai