### PR TITLE
Command examples in docs should always be copyable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,11 @@ output (and any `$` prompt) along with the command.
 - The output block holds the terminal output. Use an untagged fence (`` ``` ``) so it renders
   as plain preformatted text without syntax highlighting. Nothing in it should be copy-pasted
   back into a shell.
+- **Put an `Output:` line between them.** Mintlify automatically groups two adjacent fenced
+  code blocks into a single tabbed block (as if they were wrapped in `<CodeGroup>`), even if
+  there's a blank line between them. A plain-prose `Output:` paragraph between the command
+  and output blocks is enough non-code content to break the grouping, and it also labels the
+  second block for the reader.
 
 ### Do
 
@@ -22,6 +27,8 @@ output (and any `$` prompt) along with the command.
 ```bash
 oxen df data.tsv
 ```
+
+Output:
 
 ```
 shape: (4_774, 2)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,11 @@ shape: (4_774, 2)
 
 The "don't" version makes the copy button copy `$ oxen df data.tsv` plus the whole table.
 
+Equally wrong — and much more common in practice — is leaving the command and output in
+*separate* blocks but tagging the output block as `` ```bash ``. The copy button still sits
+on it, and readers who click it paste a table or log into their shell. If a block contains
+no runnable command, it must be untagged.
+
 ### Multiple command/output pairs
 
 If a section demonstrates several commands in sequence, make each one its own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# Oxen Docs
+
+Source for the Mintlify-hosted docs site at [docs.oxen.ai](https://docs.oxen.ai).
+
+## Authoring example terminal sessions
+
+When a page shows a command and its terminal output, put the command and the output in
+**separate fenced code blocks**. The copy button on Mintlify code blocks copies the entire
+block contents verbatim, so mixing commands and output in one block means readers copy
+output (and any `$` prompt) along with the command.
+
+- The command block is what the reader should be able to click-copy and paste into a shell.
+  Tag it with the appropriate language (`` ```bash ``, `` ```python ``, etc.) and include
+  **only** the command(s) — no leading `$` prompt, no interleaved output.
+- The output block holds the terminal output. Use an untagged fence (`` ``` ``) so it renders
+  as plain preformatted text without syntax highlighting. Nothing in it should be copy-pasted
+  back into a shell.
+
+### Do
+
+````markdown
+```bash
+oxen df data.tsv
+```
+
+```
+shape: (4_774, 2)
++-----------+---------------------------------+
+| category  | text                            |
++-----------+---------------------------------+
+| ham       | Go until jurong point...        |
++-----------+---------------------------------+
+```
+````
+
+### Don't
+
+````markdown
+```bash
+$ oxen df data.tsv
+
+shape: (4_774, 2)
++-----------+---------------------------------+
+| category  | text                            |
++-----------+---------------------------------+
+| ham       | Go until jurong point...        |
++-----------+---------------------------------+
+```
+````
+
+The "don't" version makes the copy button copy `$ oxen df data.tsv` plus the whole table.
+
+### Multiple command/output pairs
+
+If a section demonstrates several commands in sequence, make each one its own
+command/output pair rather than a single giant block. Shell comments (`# ...`) that explain
+a command belong inside the command block, on the line before the command.
+
+### Config files and structured output
+
+When the "output" is a file listing, a config file, or other structured content, tag that
+second block with the file's format (`toml`, `json`, `yaml`, ...) for syntax highlighting;
+still keep it separate from the command that produced it.

--- a/concepts/data-frames.mdx
+++ b/concepts/data-frames.mdx
@@ -20,8 +20,10 @@ oxen download datasets/SpamOrHam data.tsv
 Oxen uses the `df` command for all CLI actions involving data frames. For example, `oxen df <FILENAME>` displays the contents of tabular data files. 
 
 ```bash
-$ oxen df data.tsv
+oxen df data.tsv
+```
 
+```
 shape: (4_774, 2)
 +-----------+---------------------------------+
 | dcategory | text                            |
@@ -48,8 +50,10 @@ You can also use `oxen df` options to view your data with modifications. These c
 
 ```bash
 # Add extra column
-$ oxen df data.tsv --add-col 'language:English:str'
+oxen df data.tsv --add-col 'language:English:str'
+```
 
+```
 shape: (4_774, 3)
 +----------+---------------------------------+----------+
 | category | text                            | language |
@@ -68,10 +72,14 @@ shape: (4_774, 3)
 | ham      | Mark works tomorrow. He gets o… | English  |
 | ham      | Keep ur problems in ur heart, … | English  |
 +----------+---------------------------------+----------+
+```
 
+```bash
 # Filter out spam messages, view text only
-$ oxen df data.tsv --filter 'category == ham' --columns 'text'
+oxen df data.tsv --filter 'category == ham' --columns 'text'
+```
 
+```
 shape: (4_124, 1)
 +---------------------------------+
 | text                            |
@@ -90,10 +98,14 @@ shape: (4_124, 1)
 | Mark works tomorrow. He gets o… |
 | Keep ur problems in ur heart, … |
 +---------------------------------+
+```
 
+```bash
 # Randomize the data, then view the first 5 entries
-$ oxen df data.tsv --head 5 --randomize
+oxen df data.tsv --head 5 --randomize
+```
 
+```
 shape: (5, 2)
 +----------+---------------------------------+
 | category | text                            |
@@ -196,8 +208,10 @@ All of these operations are exposed over HTTP, so you are not limited to using t
 You can also edit data files locally with `oxen df --write`. Any modifications you make with this flag set will be written back to the original file and register as 'modified' in your Oxen repository. 
 
 ```bash
-$ oxen df data.tsv --filter 'category == spam' --write
+oxen df data.tsv --filter 'category == spam' --write
+```
 
+```
 shape: (650, 2)
 +----------+---------------------------------+
 | category | text                            |
@@ -217,9 +231,13 @@ shape: (650, 2)
 | spam     | Do you want a New Nokia 3510i … |
 +----------+---------------------------------+
 Writing "data.tsv"
+```
 
-$ oxen df data.tsv 
+```bash
+oxen df data.tsv
+```
 
+```
 shape: (650, 2)
 +----------+---------------------------------+
 | category | text                            |

--- a/concepts/data-frames.mdx
+++ b/concepts/data-frames.mdx
@@ -276,7 +276,7 @@ Some formats like parquet and arrow are more efficient for different [tasks](htt
 oxen df train.csv -o train.parquet
 ```
 
-```bash
+```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height |
@@ -302,7 +302,9 @@ Oxen has a powerful SQL query engine built in to the CLI. You can run SQL querie
 
 ```bash
 oxen df train.csv --sql 'SELECT * FROM df WHERE label = "dog"'
+```
 
+```
 shape: (4_860, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height |
@@ -319,14 +321,16 @@ shape: (4_860, 6)
 | images/000000041257.jpg ┆ dog   ┆ 6.81   ┆ 117.29 ┆ 207.06 ┆ 86.08  |
 | images/000000321014.jpg ┆ dog   ┆ 51.86  ┆ 61.18  ┆ 166.26 ┆ 63.11  |
 +-------------------------+-------+--------+--------+--------+--------+
-​```
+```
 
 ## Filter
 If you don't need a full sql query, Oxen also has a lightweight `--filter` option which supports >, <, and == operations
 
 ```bash
 oxen df train.csv --filter 'width > 100'
+```
 
+```
 shape: (3_483, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    | label | min_x  | min_y  | width  | height |
@@ -345,6 +349,7 @@ shape: (3_483, 6)
 | images/000000071025.jpg | cat   | 55.33  | 105.45 | 160.15 | 73.57  |
 | images/000000171435.jpg | dog   | 22.86  | 100.03 | 125.55 | 41.61  |
 +-------------------------+-------+--------+--------+--------+--------+
+```
 
 ## View Schema
 
@@ -356,7 +361,7 @@ To view a data frame's schema in full, you can use the `--schema` flag.
 oxen df train.csv --schema
 ```
 
-```bash
+```
 +--------+-------+
 | column | dtype |
 +----------------+
@@ -382,7 +387,7 @@ If you only need a subset of your data frame's columns, you can specify them in 
 oxen df train.csv --columns 'file,label'
 ```
 
-```bash
+```
 shape: (9_000, 2)
 +-------------------------+-------+
 | file                    ┆ label |
@@ -409,7 +414,7 @@ You can also view particular rows using `--take`
 oxen df train.csv --take '1,13,42'
 ```
 
-```bash
+```
 shape: (3, 6)
 +-------------------------+-------+-------+-------+--------+--------+
 | file                    ┆ label ┆ min_x ┆ min_y ┆ width  ┆ height |
@@ -449,7 +454,7 @@ Your data might not match the schema of a data frame you want to combine with, i
 oxen df train.csv --add-col 'is_cute:unknown:str'
 ```
 
-```bash
+```
 shape: (9_000, 7)
 +-------------------------+-------+--------+--------+--------+--------+---------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height ┆ is_cute |
@@ -476,7 +481,7 @@ You can also append new rows to the data frame. The `--add-row` option takes in 
 oxen df train.csv --add-row 'images/my_cat.jpg,cat,0,0,0,0'
 ```
 
-```bash
+```
 shape: (9_001, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height |
@@ -503,7 +508,7 @@ Often, you'll want to randomize data before splitting into train and test sets, 
 oxen df train.csv --randomize
 ```
 
-```bash
+```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height |
@@ -530,7 +535,7 @@ You can sort your data with the `sort` flag. You can sort the data by the values
 oxen df train.csv --sort "height"
 ```
 
-```bash
+```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height |
@@ -557,7 +562,7 @@ You can also reverse the order of a data table. By default `--sort` sorts in asc
 oxen df train.csv --reverse
 ```
 
-```bash
+```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    | label | min_x  | min_y  | width  | height |

--- a/concepts/data-frames.mdx
+++ b/concepts/data-frames.mdx
@@ -324,7 +324,7 @@ shape: (4_860, 6)
 ```
 
 ## Filter
-If you don't need a full sql query, Oxen also has a lightweight `--filter` option which supports >, <, and == operations
+If you don't need a full sql query, Oxen also has a lightweight `--filter` option which supports `>`, `<`, and `==` operations
 
 ```bash
 oxen df train.csv --filter 'width > 100'

--- a/concepts/data-frames.mdx
+++ b/concepts/data-frames.mdx
@@ -23,6 +23,8 @@ Oxen uses the `df` command for all CLI actions involving data frames. For exampl
 oxen df data.tsv
 ```
 
+Output:
+
 ```
 shape: (4_774, 2)
 +-----------+---------------------------------+
@@ -53,6 +55,8 @@ You can also use `oxen df` options to view your data with modifications. These c
 oxen df data.tsv --add-col 'language:English:str'
 ```
 
+Output:
+
 ```
 shape: (4_774, 3)
 +----------+---------------------------------+----------+
@@ -79,6 +83,8 @@ shape: (4_774, 3)
 oxen df data.tsv --filter 'category == ham' --columns 'text'
 ```
 
+Output:
+
 ```
 shape: (4_124, 1)
 +---------------------------------+
@@ -104,6 +110,8 @@ shape: (4_124, 1)
 # Randomize the data, then view the first 5 entries
 oxen df data.tsv --head 5 --randomize
 ```
+
+Output:
 
 ```
 shape: (5, 2)
@@ -211,6 +219,8 @@ You can also edit data files locally with `oxen df --write`. Any modifications y
 oxen df data.tsv --filter 'category == spam' --write
 ```
 
+Output:
+
 ```
 shape: (650, 2)
 +----------+---------------------------------+
@@ -236,6 +246,8 @@ Writing "data.tsv"
 ```bash
 oxen df data.tsv
 ```
+
+Output:
 
 ```
 shape: (650, 2)
@@ -276,6 +288,8 @@ Some formats like parquet and arrow are more efficient for different [tasks](htt
 oxen df train.csv -o train.parquet
 ```
 
+Output:
+
 ```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
@@ -304,6 +318,8 @@ Oxen has a powerful SQL query engine built in to the CLI. You can run SQL querie
 oxen df train.csv --sql 'SELECT * FROM df WHERE label = "dog"'
 ```
 
+Output:
+
 ```
 shape: (4_860, 6)
 +-------------------------+-------+--------+--------+--------+--------+
@@ -329,6 +345,8 @@ If you don't need a full sql query, Oxen also has a lightweight `--filter` optio
 ```bash
 oxen df train.csv --filter 'width > 100'
 ```
+
+Output:
 
 ```
 shape: (3_483, 6)
@@ -361,6 +379,8 @@ To view a data frame's schema in full, you can use the `--schema` flag.
 oxen df train.csv --schema
 ```
 
+Output:
+
 ```
 +--------+-------+
 | column | dtype |
@@ -386,6 +406,8 @@ If you only need a subset of your data frame's columns, you can specify them in 
 ```bash
 oxen df train.csv --columns 'file,label'
 ```
+
+Output:
 
 ```
 shape: (9_000, 2)
@@ -413,6 +435,8 @@ You can also view particular rows using `--take`
 ```bash
 oxen df train.csv --take '1,13,42'
 ```
+
+Output:
 
 ```
 shape: (3, 6)
@@ -454,6 +478,8 @@ Your data might not match the schema of a data frame you want to combine with, i
 oxen df train.csv --add-col 'is_cute:unknown:str'
 ```
 
+Output:
+
 ```
 shape: (9_000, 7)
 +-------------------------+-------+--------+--------+--------+--------+---------+
@@ -480,6 +506,8 @@ You can also append new rows to the data frame. The `--add-row` option takes in 
 ```bash
 oxen df train.csv --add-row 'images/my_cat.jpg,cat,0,0,0,0'
 ```
+
+Output:
 
 ```
 shape: (9_001, 6)
@@ -508,6 +536,8 @@ Often, you'll want to randomize data before splitting into train and test sets, 
 oxen df train.csv --randomize
 ```
 
+Output:
+
 ```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
@@ -535,6 +565,8 @@ You can sort your data with the `sort` flag. You can sort the data by the values
 oxen df train.csv --sort "height"
 ```
 
+Output:
+
 ```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
@@ -561,6 +593,8 @@ You can also reverse the order of a data table. By default `--sort` sorts in asc
 ```bash
 oxen df train.csv --reverse
 ```
+
+Output:
 
 ```
 shape: (9_000, 6)

--- a/concepts/diffs.mdx
+++ b/concepts/diffs.mdx
@@ -670,6 +670,8 @@ Quickly inspect the `model_results.csv` file with the `oxen df` command to make 
 oxen df model_results.csv
 ```
 
+Output:
+
 ```
 shape: (6, 8)
 +-----+--------------------------+------------------------+-------------+--------------------------------+------------+-------+----------------+

--- a/concepts/file_metadata.mdx
+++ b/concepts/file_metadata.mdx
@@ -23,6 +23,8 @@ To list all the schemas that have been detected and committed, you can use the `
 oxen schemas
 ```
 
+Output:
+
 ```
 +-----------------------+------+----------------------------------+------------------------+
 | path                  | name | hash                             | fields                 |
@@ -42,6 +44,8 @@ To view a specific schema, you can pass in a schema hash, name, or path to the `
 ```bash
 oxen schemas annotations/train.csv
 ```
+
+Output:
 
 ```
 +--------+-------+----------+
@@ -70,6 +74,8 @@ oxen add annotations/train.csv
 oxen status
 ```
 
+Output:
+
 ```
 On branch main -> 503591398980c485
 
@@ -90,6 +96,8 @@ To view more detailed information about the detected schema, use the `--staged` 
 ```bash
 oxen schemas --staged annotations/train.csv
 ```
+
+Output:
 
 ```
 annotations/train.csv 23d86a4c1481b817b57ee8ccd7d9016b
@@ -119,6 +127,8 @@ To view how Polars interprets the schema before adding the file, you can use the
 ```bash
 oxen df annotations/train.csv --schema
 ```
+
+Output:
 
 ```
 +-----------+-------+
@@ -198,6 +208,8 @@ You can also add metadata to specific columns. Say you wanted to add information
 oxen schemas add annotations/train.csv -c 'file' -m '{"root": "images/"}'
 ```
 
+Output:
+
 ```
 "annotations/train.csv"
 +-----------+-------+---------------------+
@@ -236,6 +248,8 @@ To view the schemas staged for commit, you can use the `--staged` flag.
 ```bash
 oxen schemas --staged
 ```
+
+Output:
 
 ```
 +-----------------------+------+----------------------------------+--------------------+

--- a/concepts/file_metadata.mdx
+++ b/concepts/file_metadata.mdx
@@ -23,7 +23,7 @@ To list all the schemas that have been detected and committed, you can use the `
 oxen schemas
 ```
 
-```bash
+```
 +-----------------------+------+----------------------------------+------------------------+
 | path                  | name | hash                             | fields                 |
 +==========================================================================================+
@@ -43,7 +43,7 @@ To view a specific schema, you can pass in a schema hash, name, or path to the `
 oxen schemas annotations/train.csv
 ```
 
-```bash
+```
 +--------+-------+----------+
 | name   | dtype | metadata |
 +===========================+
@@ -70,7 +70,7 @@ oxen add annotations/train.csv
 oxen status
 ```
 
-```bash
+```
 On branch main -> 503591398980c485
 
 Directories to be committed
@@ -91,7 +91,7 @@ To view more detailed information about the detected schema, use the `--staged` 
 oxen schemas --staged annotations/train.csv
 ```
 
-```bash
+```
 annotations/train.csv 23d86a4c1481b817b57ee8ccd7d9016b
 +-----------+-------+----------+
 | name      | dtype | metadata |
@@ -120,7 +120,7 @@ To view how Polars interprets the schema before adding the file, you can use the
 oxen df annotations/train.csv --schema
 ```
 
-```bash
+```
 +-----------+-------+
 | column    | dtype |
 +===================+
@@ -237,7 +237,7 @@ To view the schemas staged for commit, you can use the `--staged` flag.
 oxen schemas --staged
 ```
 
-```bash
+```
 +-----------------------+------+----------------------------------+--------------------+
 | path                  | name | hash                             | fields             |
 +======================================================================================+

--- a/features/data_frames.mdx
+++ b/features/data_frames.mdx
@@ -352,7 +352,7 @@ shape: (4_860, 6)
 ```
 
 ## Filter
-If you don't need a full sql query, Oxen also has a lightweight `--filter` option which supports >, <, and == operations
+If you don't need a full sql query, Oxen also has a lightweight `--filter` option which supports `>`, `<`, and `==` operations
 
 ```bash
 oxen df train.csv --filter 'width > 100'

--- a/features/data_frames.mdx
+++ b/features/data_frames.mdx
@@ -48,8 +48,10 @@ Oxen also provides command line tools to interact with data frames. This makes i
 `oxen df` is a handy subcommand to interact with data frames locally. For example, `oxen df <FILENAME>` displays the contents of tabular data files.
 
 ```bash
-$ oxen df data.tsv
+oxen df data.tsv
+```
 
+```
 shape: (4_774, 2)
 +-----------+---------------------------------+
 | dcategory | text                            |
@@ -76,8 +78,10 @@ You can also use `oxen df` options to view your data with modifications. These c
 
 ```bash
 # Add extra column
-$ oxen df data.tsv --add-col 'language:English:str'
+oxen df data.tsv --add-col 'language:English:str'
+```
 
+```
 shape: (4_774, 3)
 +----------+---------------------------------+----------+
 | category | text                            | language |
@@ -96,10 +100,14 @@ shape: (4_774, 3)
 | ham      | Mark works tomorrow. He gets o… | English  |
 | ham      | Keep ur problems in ur heart, … | English  |
 +----------+---------------------------------+----------+
+```
 
+```bash
 # Filter out spam messages, view text only
-$ oxen df data.tsv --filter 'category == ham' --columns 'text'
+oxen df data.tsv --filter 'category == ham' --columns 'text'
+```
 
+```
 shape: (4_124, 1)
 +---------------------------------+
 | text                            |
@@ -118,10 +126,14 @@ shape: (4_124, 1)
 | Mark works tomorrow. He gets o… |
 | Keep ur problems in ur heart, … |
 +---------------------------------+
+```
 
+```bash
 # Randomize the data, then view the first 5 entries
-$ oxen df data.tsv --head 5 --randomize
+oxen df data.tsv --head 5 --randomize
+```
 
+```
 shape: (5, 2)
 +----------+---------------------------------+
 | category | text                            |
@@ -224,8 +236,10 @@ All of these operations are exposed over HTTP, so you are not limited to using t
 You can also edit data files locally with `oxen df --write`. Any modifications you make with this flag set will be written back to the original file and register as 'modified' in your Oxen repository.
 
 ```bash
-$ oxen df data.tsv --filter 'category == spam' --write
+oxen df data.tsv --filter 'category == spam' --write
+```
 
+```
 shape: (650, 2)
 +----------+---------------------------------+
 | category | text                            |
@@ -245,9 +259,13 @@ shape: (650, 2)
 | spam     | Do you want a New Nokia 3510i … |
 +----------+---------------------------------+
 Writing "data.tsv"
+```
 
-$ oxen df data.tsv
+```bash
+oxen df data.tsv
+```
 
+```
 shape: (650, 2)
 +----------+---------------------------------+
 | category | text                            |

--- a/features/data_frames.mdx
+++ b/features/data_frames.mdx
@@ -51,6 +51,8 @@ Oxen also provides command line tools to interact with data frames. This makes i
 oxen df data.tsv
 ```
 
+Output:
+
 ```
 shape: (4_774, 2)
 +-----------+---------------------------------+
@@ -81,6 +83,8 @@ You can also use `oxen df` options to view your data with modifications. These c
 oxen df data.tsv --add-col 'language:English:str'
 ```
 
+Output:
+
 ```
 shape: (4_774, 3)
 +----------+---------------------------------+----------+
@@ -107,6 +111,8 @@ shape: (4_774, 3)
 oxen df data.tsv --filter 'category == ham' --columns 'text'
 ```
 
+Output:
+
 ```
 shape: (4_124, 1)
 +---------------------------------+
@@ -132,6 +138,8 @@ shape: (4_124, 1)
 # Randomize the data, then view the first 5 entries
 oxen df data.tsv --head 5 --randomize
 ```
+
+Output:
 
 ```
 shape: (5, 2)
@@ -239,6 +247,8 @@ You can also edit data files locally with `oxen df --write`. Any modifications y
 oxen df data.tsv --filter 'category == spam' --write
 ```
 
+Output:
+
 ```
 shape: (650, 2)
 +----------+---------------------------------+
@@ -264,6 +274,8 @@ Writing "data.tsv"
 ```bash
 oxen df data.tsv
 ```
+
+Output:
 
 ```
 shape: (650, 2)
@@ -304,6 +316,8 @@ Some formats like parquet and arrow are more efficient for different [tasks](htt
 oxen df train.csv -o train.parquet
 ```
 
+Output:
+
 ```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
@@ -332,6 +346,8 @@ Oxen has a powerful SQL query engine built in to the CLI. You can run SQL querie
 oxen df train.csv --sql 'SELECT * FROM df WHERE label = "dog"'
 ```
 
+Output:
+
 ```
 shape: (4_860, 6)
 +-------------------------+-------+--------+--------+--------+--------+
@@ -357,6 +373,8 @@ If you don't need a full sql query, Oxen also has a lightweight `--filter` optio
 ```bash
 oxen df train.csv --filter 'width > 100'
 ```
+
+Output:
 
 ```
 shape: (3_483, 6)
@@ -389,6 +407,8 @@ To view a data frame's schema in full, you can use the `--schema` flag.
 oxen df train.csv --schema
 ```
 
+Output:
+
 ```
 +--------+-------+
 | column | dtype |
@@ -414,6 +434,8 @@ If you only need a subset of your data frame's columns, you can specify them in 
 ```bash
 oxen df train.csv --columns 'file,label'
 ```
+
+Output:
 
 ```
 shape: (9_000, 2)
@@ -441,6 +463,8 @@ You can also view particular rows using `--take`
 ```bash
 oxen df train.csv --take '1,13,42'
 ```
+
+Output:
 
 ```
 shape: (3, 6)
@@ -482,6 +506,8 @@ Your data might not match the schema of a data frame you want to combine with, i
 oxen df train.csv --add-col 'is_cute:unknown:str'
 ```
 
+Output:
+
 ```
 shape: (9_000, 7)
 +-------------------------+-------+--------+--------+--------+--------+---------+
@@ -508,6 +534,8 @@ You can also append new rows to the data frame. The `--add-row` option takes in 
 ```bash
 oxen df train.csv --add-row 'images/my_cat.jpg,cat,0,0,0,0'
 ```
+
+Output:
 
 ```
 shape: (9_001, 6)
@@ -536,6 +564,8 @@ Often, you'll want to randomize data before splitting into train and test sets, 
 oxen df train.csv --randomize
 ```
 
+Output:
+
 ```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
@@ -563,6 +593,8 @@ You can sort your data with the `sort` flag. You can sort the data by the values
 oxen df train.csv --sort "height"
 ```
 
+Output:
+
 ```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
@@ -589,6 +621,8 @@ You can also reverse the order of a data table. By default `--sort` sorts in asc
 ```bash
 oxen df train.csv --reverse
 ```
+
+Output:
 
 ```
 shape: (9_000, 6)

--- a/features/data_frames.mdx
+++ b/features/data_frames.mdx
@@ -304,7 +304,7 @@ Some formats like parquet and arrow are more efficient for different [tasks](htt
 oxen df train.csv -o train.parquet
 ```
 
-```bash
+```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height |
@@ -330,7 +330,9 @@ Oxen has a powerful SQL query engine built in to the CLI. You can run SQL querie
 
 ```bash
 oxen df train.csv --sql 'SELECT * FROM df WHERE label = "dog"'
+```
 
+```
 shape: (4_860, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height |
@@ -347,14 +349,16 @@ shape: (4_860, 6)
 | images/000000041257.jpg ┆ dog   ┆ 6.81   ┆ 117.29 ┆ 207.06 ┆ 86.08  |
 | images/000000321014.jpg ┆ dog   ┆ 51.86  ┆ 61.18  ┆ 166.26 ┆ 63.11  |
 +-------------------------+-------+--------+--------+--------+--------+
-​```
+```
 
 ## Filter
 If you don't need a full sql query, Oxen also has a lightweight `--filter` option which supports >, <, and == operations
 
 ```bash
 oxen df train.csv --filter 'width > 100'
+```
 
+```
 shape: (3_483, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    | label | min_x  | min_y  | width  | height |
@@ -373,6 +377,7 @@ shape: (3_483, 6)
 | images/000000071025.jpg | cat   | 55.33  | 105.45 | 160.15 | 73.57  |
 | images/000000171435.jpg | dog   | 22.86  | 100.03 | 125.55 | 41.61  |
 +-------------------------+-------+--------+--------+--------+--------+
+```
 
 ## View Schema
 
@@ -384,7 +389,7 @@ To view a data frame's schema in full, you can use the `--schema` flag.
 oxen df train.csv --schema
 ```
 
-```bash
+```
 +--------+-------+
 | column | dtype |
 +----------------+
@@ -410,7 +415,7 @@ If you only need a subset of your data frame's columns, you can specify them in 
 oxen df train.csv --columns 'file,label'
 ```
 
-```bash
+```
 shape: (9_000, 2)
 +-------------------------+-------+
 | file                    ┆ label |
@@ -437,7 +442,7 @@ You can also view particular rows using `--take`
 oxen df train.csv --take '1,13,42'
 ```
 
-```bash
+```
 shape: (3, 6)
 +-------------------------+-------+-------+-------+--------+--------+
 | file                    ┆ label ┆ min_x ┆ min_y ┆ width  ┆ height |
@@ -477,7 +482,7 @@ Your data might not match the schema of a data frame you want to combine with, i
 oxen df train.csv --add-col 'is_cute:unknown:str'
 ```
 
-```bash
+```
 shape: (9_000, 7)
 +-------------------------+-------+--------+--------+--------+--------+---------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height ┆ is_cute |
@@ -504,7 +509,7 @@ You can also append new rows to the data frame. The `--add-row` option takes in 
 oxen df train.csv --add-row 'images/my_cat.jpg,cat,0,0,0,0'
 ```
 
-```bash
+```
 shape: (9_001, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height |
@@ -531,7 +536,7 @@ Often, you'll want to randomize data before splitting into train and test sets, 
 oxen df train.csv --randomize
 ```
 
-```bash
+```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height |
@@ -558,7 +563,7 @@ You can sort your data with the `sort` flag. You can sort the data by the values
 oxen df train.csv --sort "height"
 ```
 
-```bash
+```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    ┆ label ┆ min_x  ┆ min_y  ┆ width  ┆ height |
@@ -585,7 +590,7 @@ You can also reverse the order of a data table. By default `--sort` sorts in asc
 oxen df train.csv --reverse
 ```
 
-```bash
+```
 shape: (9_000, 6)
 +-------------------------+-------+--------+--------+--------+--------+
 | file                    | label | min_x  | min_y  | width  | height |

--- a/getting-started/command-line/dev_tools.mdx
+++ b/getting-started/command-line/dev_tools.mdx
@@ -10,6 +10,9 @@ You can use `oxen tree` to view the current state of the merkle tree for a commi
 ```bash
 oxen tree
 ```
+
+Output:
+
 ```
 [Commit] 74bb3ece2ccfa3f23420ef5c0be84865 (0.36.0) "Add Data" -> Daisy daisy@oxen.ai parent_ids ""
   [Dir] 65d46b6d56 "" (3.5 MB) (4 files) (commit 74bb3ece2c)  (3 entries)
@@ -32,6 +35,9 @@ Time to load tree: 4.8259ms
 ```bash
 oxen node -n 65d46b6d5616364ba975320b5768c63c
 ```
+
+Output:
+
 ```
 [Dir] 65d46b6d56 "" (3.5 MB) (4 files) (commit 74bb3ece2c)  (3 entries)
 =============
@@ -54,6 +60,9 @@ children.len(): 1
 ```bash 
 oxen node -p dir/image.png
 ```
+
+Output:
+
 ```
 [File] b04c7235e3 "image.png" (image/png) 95.1 KB [b04c7235e3] (commit 74bb3ece2c) MetadataImage(1798x839)
 =============

--- a/getting-started/command-line/local_development.mdx
+++ b/getting-started/command-line/local_development.mdx
@@ -161,13 +161,13 @@ You can also use `oxen restore` on directories to recursively restore their file
 If you want to restore to a specific version in your commit history, you can supply the commit id or branch name with the `--source` flag.
 
 ```bash
-$ oxen restore path/to/file.txt --source COMMIT_ID
+oxen restore path/to/file.txt --source COMMIT_ID
 ```
 
 As with git, you can also restore files from the `staged_db` using `oxen restore --staged`
 
 ```bash
-$ oxen restore --staged path/to/dir
+oxen restore --staged path/to/dir
 ```
 
 ## Removing Data

--- a/getting-started/command-line/local_development.mdx
+++ b/getting-started/command-line/local_development.mdx
@@ -42,6 +42,9 @@ This can be used to stage new, modified, or removed files and directories to the
 ``` bash
 oxen status
 ```
+
+Output:
+
 ```
 On branch main -> 113b00a451ac07d284b29ce5604d6891
 
@@ -72,6 +75,8 @@ You can see the history of changes on your current branch by running:
 ```bash
 oxen log
 ```
+
+Output:
 
 ```
 commit 6b958e268656b0c5
@@ -121,6 +126,8 @@ Note: since we are dealing with large datasets with many files, `status` rolls u
 ```bash
 oxen status
 ```
+
+Output:
 
 ```
 On branch main -> e76dd52a4fc13a6f

--- a/getting-started/command-line/push_changes.mdx
+++ b/getting-started/command-line/push_changes.mdx
@@ -39,6 +39,9 @@ The `oxen remote` command allows you to view what remotes you have for a reposit
 ```bash
 oxen remote
 ```
+
+Output:
+
 ```
 origin
 ```
@@ -48,6 +51,9 @@ Use the `--verbose` flag to list the remotes with their URLs
 ```bash
 oxen remote --verbose
 ```
+
+Output:
+
 ```
 origin  https://hub.oxen.ai/ox/CatDogBBox
 local_dev   http://localhost:3000/ox/CatDogBBox

--- a/getting-started/install.mdx
+++ b/getting-started/install.mdx
@@ -25,17 +25,17 @@ First, download the release for your system's architecture.
 
 For x86-64
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-linux-x86_64.deb
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-linux-x86_64.deb
 ```
 
 For ARM64
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-linux-arm64.deb
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-linux-arm64.deb
 ```
 
 Then run
 ```bash
-$ sudo dpkg -i oxen-linux-*.deb
+sudo dpkg -i oxen-linux-*.deb
 ```
 
 #### Other distributions
@@ -45,24 +45,24 @@ First, download the release for your system's architecture.
 
 For x86-64
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-linux-x86_64.tar.gz
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-linux-x86_64.tar.gz
 ```
 
 For ARM64
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-linux-arm64.tar.gz
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-linux-arm64.tar.gz
 ```
 
 ```bash
-$ tar -xzvf oxen-linux-*.tar.gz
-$ chmod +x oxen
-$ mv oxen /usr/local/bin
+tar -xzvf oxen-linux-*.tar.gz
+chmod +x oxen
+mv oxen /usr/local/bin
 ```
 
 ### Windows
 We provide Windows binaries as a .exe.
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-windows-x86_64.exe.zip
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-windows-x86_64.exe.zip
 ```
 
 ## Python Package
@@ -72,20 +72,20 @@ The easiest way to get started with the Oxen Python library is to use `uv`. [Ins
 Install a supported Python version
 
 ```bash
-$ uv python install 3.13
+uv python install 3.13
 ```
 
 Then, create and init a new uv project.
 ```bash
-$ mkdir my-python-script/ && cd my-python-script/
-$ uv init
+mkdir my-python-script/ && cd my-python-script/
+uv init
 ```
 
 This will create a virtual environment with the latest installed Python version.
 
 Next, add the oxen library to the project
 ```bash
-$ uv add oxenai
+uv add oxenai
 ```
 
 Then, to test that everything is working, update `main.py` with the following code.
@@ -96,7 +96,7 @@ oxen.clone("ox/SpanishToEnglish")
 
 Then run the script with `uv run` so it executes in the virtual environment.
 ```bash
-$ uv run main.py
+uv run main.py
 ```
 
 Note that this will only install the Python library and not the command line tool.
@@ -131,8 +131,8 @@ The Oxen server binary can be deployed where ever you want to store and backup y
 ### Mac
 
 ```bash
-$ brew tap Oxen-AI/oxen-server
-$ brew install oxen-server
+brew tap Oxen-AI/oxen-server
+brew install oxen-server
 ```
 
 ### Docker
@@ -141,12 +141,12 @@ First, download the Docker image based on the host architecture.
 
 For x86-64
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-docker-x86_64.tar
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-docker-x86_64.tar
 ```
 
 For ARM64
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-docker-arm64.tar
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-docker-arm64.tar
 ```
 
 Then, load the image into Docker.
@@ -167,17 +167,17 @@ First, download the release for your system's architecture.
 
 For x86-64
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-linux-x86_64.deb
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-linux-x86_64.deb
 ```
 
 For ARM64
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-linux-arm64.deb
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-linux-arm64.deb
 ```
 
 Then run
 ```bash
-$ sudo dpkg -i oxen-server-linux-*.deb
+sudo dpkg -i oxen-server-linux-*.deb
 ```
 
 #### Other distributions
@@ -185,25 +185,25 @@ First, download the release for your system's architecture.
 
 For x86-64
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-linux-x86_64.tar.gz
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-linux-x86_64.tar.gz
 ```
 
 For ARM64
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-linux-arm64.tar.gz
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-linux-arm64.tar.gz
 ```
 
 ```bash
-$ tar -xzvf oxen-server-linux-*.tar.gz
-$ chmod +x oxen-server
-$ mv oxen-server /usr/local/bin
+tar -xzvf oxen-server-linux-*.tar.gz
+chmod +x oxen-server
+mv oxen-server /usr/local/bin
 ```
 
 ### Windows
 We provide Windows binaries as a .exe.
 
 ```bash
-$ wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-windows-x86_64.exe.zip
+wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-windows-x86_64.exe.zip
 ```
 
 To get up and running using the client and server, you can follow the [getting started docs](https://github.com/Oxen-AI/oxen).

--- a/getting-started/oxen-server.mdx
+++ b/getting-started/oxen-server.mdx
@@ -60,7 +60,9 @@ To enable authentication, generate a token to give it to the user to access to t
 
 ```bash
 oxen-server add-user --email YOUR_EMAIL --name YOUR_NAME
+```
 
+```
 User access token created:
 
 XXXXXXXX

--- a/getting-started/oxen-server.mdx
+++ b/getting-started/oxen-server.mdx
@@ -62,6 +62,8 @@ To enable authentication, generate a token to give it to the user to access to t
 oxen-server add-user --email YOUR_EMAIL --name YOUR_NAME
 ```
 
+Output:
+
 ```
 User access token created:
 
@@ -91,6 +93,8 @@ The default directory that Oxen stores data is `/tmp/oxen_sync`, which is not a 
 export SYNC_DIR=/var/oxen/data
 oxen-server start -a
 ```
+
+Output:
 
 ```
 Running 🐂 server on 0.0.0.0:3000
@@ -135,6 +139,8 @@ When you create a remote repository, Oxen will create a directory for it on the 
 ```bash
 ls /var/oxen/data/my_namespace/repo_name/.oxen
 ```
+
+Output:
 
 ```
 config.toml
@@ -182,6 +188,8 @@ If you look in your local repository, you will see the `.oxen` directory.
 ls .oxen
 ```
 
+Output:
+
 ```
 config.toml
 history/
@@ -200,6 +208,8 @@ If you look at the `config.toml` file, you will see the remote set.
 ```bash
 cat .oxen/config.toml
 ```
+
+Output:
 
 ```toml
 remote_name = "origin"

--- a/getting-started/oxen-server.mdx
+++ b/getting-started/oxen-server.mdx
@@ -85,10 +85,12 @@ oxen-server start -a
 
 The default directory that Oxen stores data is `/tmp/oxen_sync`, which is not a good idea for production. To change it set the `SYNC_DIR` environment variable to a path.
 
-```
-$ export SYNC_DIR=/var/oxen/data
+```bash
+export SYNC_DIR=/var/oxen/data
 oxen-server start -a
+```
 
+```
 Running 🐂 server on 0.0.0.0:3000
 Syncing to directory: /var/oxen/data
 [2022-06-08T10:00:48Z INFO  actix_server::builder] Starting 8 workers
@@ -129,8 +131,10 @@ You can either clone data from this remote repository, or push data to it.
 When you create a remote repository, Oxen will create a directory for it on the server. The directory structure is `$SYNC_DIR/<namespace>/<repo_name>/.oxen`.
 
 ```bash
-$ ls /var/oxen/data/my_namespace/repo_name/.oxen
+ls /var/oxen/data/my_namespace/repo_name/.oxen
+```
 
+```
 config.toml
 history/
 refs/
@@ -173,8 +177,10 @@ oxen commit -m "Initial commit"
 If you look in your local repository, you will see the `.oxen` directory.
 
 ```bash
-$ ls .oxen
+ls .oxen
+```
 
+```
 config.toml
 history/
 refs/
@@ -190,8 +196,10 @@ oxen config --set-remote origin http://localhost:3000/my_namespace/repo_name
 
 If you look at the `config.toml` file, you will see the remote set.
 ```bash
-$ cat .oxen/config.toml
+cat .oxen/config.toml
+```
 
+```toml
 remote_name = "origin"
 
 [[remotes]]

--- a/getting-started/python.mdx
+++ b/getting-started/python.mdx
@@ -286,6 +286,8 @@ repo = Repo("CatsVsDogs")
 print(repo.branches())
 ```
 
+Output:
+
 ```
 [Branch(name=add-dogs, commit_id=3168391af834ac18), Branch(name=main, commit_id=3168391af834ac18)]
 ```

--- a/getting-started/versioning.mdx
+++ b/getting-started/versioning.mdx
@@ -443,6 +443,8 @@ View the change you made with the `oxen diff` command. This will show you the ch
 oxen diff image_classification_data.csv
 ```
 
+Output:
+
 ```
 Column changes:
    + label (str)


### PR DESCRIPTION
We received some feedback that when users clicked on the copy-icon in the rendered docs, they were sometimes copying more than just the command--the leading `$` or the output following the command.

This updates the docs so that users can always safely copy and paste commands without extra non-command output being included on the clipboard.

---

Before:

<img width="755" height="186" alt="Screenshot 2026-04-24 at 10 44 25 AM" src="https://github.com/user-attachments/assets/d778ee75-a658-4720-aea1-74d5d9bb5c53" />

After:

<img width="741" height="175" alt="image" src="https://github.com/user-attachments/assets/2cdfbcb9-1061-40f8-b221-d129b71815c4" />

---

Before:

<img width="761" height="283" alt="image" src="https://github.com/user-attachments/assets/97181aee-c5df-46bd-9246-33776c205e1a" />

After:

<img width="769" height="378" alt="image" src="https://github.com/user-attachments/assets/2f96aecf-baaf-4658-a5e9-395ef5b2c87c" />
