### PR TITLE
Revamp getting started pages

### DIFF
--- a/getting-started/intro.mdx
+++ b/getting-started/intro.mdx
@@ -1,13 +1,15 @@
 ---
 title: 🐂 Oxen.ai
-description: Infrastructure for collaborating on datasets and fine-tuning open source models.
+description: One place for your generations, your models, and your data.
 ---
 
 <img alt="Oxen.ai Moon Ox Hero" className="rounded-xl" classname="block" src="/images/MoonOx.png" />
 
-Oxen.ai gives you the tools to [fine-tune](/getting-started/fine-tuning) open source [models](/getting-started/inference) on your own [datasets](/getting-started/datasets). We believe that your data is your differentiator, and training models on your own data should be easy, fast, and approachable for everyone.
-
-The platform makes it easy to spin up GPU infrastructure to [train models](/examples/notebooks/train_llm) or run [inference](/getting-started/inference) at scale. Never lose track of which [dataset](/getting-started/datasets) trained which [model](/getting-started/fine-tuning) because all files are [version controlled](/getting-started/versioning) in a [repository](/getting-started/versioning). Kick off many experiments in parallel and easily collaborate with your team.
+Oxen.ai is a platform for working with AI. Use it through our workbench or build with our APIs. Here are a few highlights of what you can do with our platform:
+* Use hundreds of [models](/getting-started/inference) to generate text, images, and video. Everything you create is automatically saved and organized in your projects.
+* Your data matters. Oxen.ai keeps everything organized and versioned, whether you're managing a creative project or curating training data that makes your models stand out.
+* [Fine-tune](/getting-started/fine-tuning) a model on your own data to make it yours.
+* Deploy your models for scalable inference, download the weights, or share them with your team.
 
 ## ✅ Features
 


### PR DESCRIPTION
This is a WIP!

This was a start at revamping the copy in the docs, mainly to shift the focus away from finetuning and give a better picture of our product, better point towards our available resources (use cases vs API references), and improve the layout and organization of the docs.