### PR TITLE
Fix duplicate auth header in regenerate-model-docs workflow

### DIFF
--- a/.github/workflows/regenerate-model-docs.yml
+++ b/.github/workflows/regenerate-model-docs.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Tells `actions/checkout` not to persist credentials so `peter-evans/create-pull-request` is the only Authorization header on the wire, fixing the 400 'Duplicate header' error when running the workflow