### PR TITLE
Document how to use multi image input

### DIFF
--- a/inference-api/reference/image_editing.mdx
+++ b/inference-api/reference/image_editing.mdx
@@ -17,7 +17,7 @@ Edit an existing image using a text prompt. The request blocks until the edited 
 |---|---|---|---|---|
 | `model` | string | **yes** | -- | Image editing model (e.g. `qwen-image-edit`, `nano-banana-2-edit`, `xai-grok-imagine-image-edit`) |
 | `prompt` | string | **yes** | -- | Description of the edit to apply. |
-| `input_image` | string (URL) | **yes** | -- | URL of the image to edit. Must be publicly accessible. |
+| `input_image` | string \| array of strings (URL) | **yes** | -- | URL of the image to edit. Most models accept a single URL string; multi-image models (e.g. `gpt-image-2-edit`, `nano-banana-2-edit`, `qwen-image-edit-2511`) accept an array of URLs for multi-reference composition. Check the [per-model reference](/inference-api/reference/model-references) for the exact type a given model expects. URLs must be publicly accessible — data URIs (`data:image/...;base64,...`) also work but are not recommended for production. |
 | `response_format` | string | no | `"url"` | `"url"` returns a hosted URL. `"b64_json"` returns base64-encoded image bytes inline. |
 | `target_namespace` | string | no | current user | Namespace to save results and bill to. Can be an organization name. |
 
@@ -59,6 +59,50 @@ curl -X POST https://hub.oxen.ai/api/ai/images/edit \
 ```
 
 </CodeGroup>
+
+### Multi-image composition
+
+Some models accept multiple reference images at once for multi-reference composition. Pass `input_image` as an array of URLs:
+
+<CodeGroup>
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://hub.oxen.ai/api/ai/images/edit",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "gpt-image-2-edit",
+        "prompt": "Combine these references into a single scene",
+        "input_image": [
+            "https://example.com/reference-a.png",
+            "https://example.com/reference-b.png",
+        ],
+    },
+)
+```
+
+```bash cURL
+curl -X POST https://hub.oxen.ai/api/ai/images/edit \
+  -H "Authorization: Bearer $OXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-image-2-edit",
+    "prompt": "Combine these references into a single scene",
+    "input_image": [
+      "https://example.com/reference-a.png",
+      "https://example.com/reference-b.png"
+    ]
+  }'
+```
+
+</CodeGroup>
+
+Whether a model accepts a single image or an array of images is part of its schema — see each model's [API reference](/inference-api/reference/model-references) for the exact type.
 
 ### Response
 

--- a/inference-api/reference/image_editing.mdx
+++ b/inference-api/reference/image_editing.mdx
@@ -17,7 +17,7 @@ Edit an existing image using a text prompt. The request blocks until the edited 
 |---|---|---|---|---|
 | `model` | string | **yes** | -- | Image editing model (e.g. `qwen-image-edit`, `nano-banana-2-edit`, `xai-grok-imagine-image-edit`) |
 | `prompt` | string | **yes** | -- | Description of the edit to apply. |
-| `input_image` | string \| array of strings (URL) | **yes** | -- | URL of the image to edit. Most models accept a single URL string; multi-image models (e.g. `gpt-image-2-edit`, `nano-banana-2-edit`, `qwen-image-edit-2511`) accept an array of URLs for multi-reference composition. Check the [per-model reference](/inference-api/reference/model-references) for the exact type a given model expects. URLs must be publicly accessible — data URIs (`data:image/...;base64,...`) also work but are not recommended for production. |
+| `input_image` | string \| array of strings (URL) | **yes** | -- | URL of the image to edit. Most models accept a single URL string; multi-image models (e.g. `gpt-image-2-edit`, `nano-banana-2-edit`, `qwen-image-edit-2511`) accept an array of URLs for multi-reference composition. Check the [per-model reference](/inference-api/reference/model-references) for the exact type a given model expects. URLs must be publicly accessible. Data URIs (`data:image/...;base64,...`) also work but are not recommended for production. |
 | `response_format` | string | no | `"url"` | `"url"` returns a hosted URL. `"b64_json"` returns base64-encoded image bytes inline. |
 | `target_namespace` | string | no | current user | Namespace to save results and bill to. Can be an organization name. |
 
@@ -102,7 +102,7 @@ curl -X POST https://hub.oxen.ai/api/ai/images/edit \
 
 </CodeGroup>
 
-Whether a model accepts a single image or an array of images is part of its schema — see each model's [API reference](/inference-api/reference/model-references) for the exact type.
+Whether a model accepts a single image or an array of images is part of its schema. See each model's [API reference](/inference-api/reference/model-references) for the exact type.
 
 ### Response
 

--- a/inference-api/reference/image_editing.mdx
+++ b/inference-api/reference/image_editing.mdx
@@ -17,7 +17,7 @@ Edit an existing image using a text prompt. The request blocks until the edited 
 |---|---|---|---|---|
 | `model` | string | **yes** | -- | Image editing model (e.g. `qwen-image-edit`, `nano-banana-2-edit`, `xai-grok-imagine-image-edit`) |
 | `prompt` | string | **yes** | -- | Description of the edit to apply. |
-| `input_image` | string \| array of strings (URL) | **yes** | -- | URL of the image to edit. Most models accept a single URL string; multi-image models (e.g. `gpt-image-2-edit`, `nano-banana-2-edit`, `qwen-image-edit-2511`) accept an array of URLs for multi-reference composition. Check the [per-model reference](/inference-api/reference/model-references) for the exact type a given model expects. URLs must be publicly accessible. Data URIs (`data:image/...;base64,...`) also work but are not recommended for production. |
+| `input_image` | string/array | **yes** | -- | URL(s) of the image to edit. Some models accept an array; see [per-model reference](/inference-api/reference/model-references). |
 | `response_format` | string | no | `"url"` | `"url"` returns a hosted URL. `"b64_json"` returns base64-encoded image bytes inline. |
 | `target_namespace` | string | no | current user | Namespace to save results and bill to. Can be an organization name. |
 

--- a/inference-api/reference/image_editing.mdx
+++ b/inference-api/reference/image_editing.mdx
@@ -127,4 +127,4 @@ Same format as `/ai/images/generate`:
 | Image URL not accessible | `"... 403 Client Error: Forbidden for url: ..."` |
 | Model not found | `"Model not found: <name>"` |
 
-The `input_image` URL must be publicly downloadable. URLs that require authentication or block automated access will fail.
+The `input_image` URL must be publicly downloadable. URLs that require authentication or block automated access will fail. Data URIs (`data:image/...;base64,...`) work as an alternative but aren't recommended for production.

--- a/inference-api/reference/image_editing.mdx
+++ b/inference-api/reference/image_editing.mdx
@@ -60,9 +60,9 @@ curl -X POST https://hub.oxen.ai/api/ai/images/edit \
 
 </CodeGroup>
 
-### Multi-image composition
+### Multi-image input
 
-Some models accept multiple reference images at once for multi-reference composition. Pass `input_image` as an array of URLs:
+Some models accept an array of URLs in `input_image`. Consult the per-model reference for how each model uses them:
 
 <CodeGroup>
 


### PR DESCRIPTION
Updates the image-editing reference to note that `input_image` can be a string or an array of strings depending on the model, with a short example for multi-image composition and a pointer to the per-model API references for the exact type. Adds a one-liner that data URIs technically work but are not recommended for production.