### PR TITLE
Bump action versions - docs

### DIFF
--- a/.github/workflows/regenerate-model-docs.yml
+++ b/.github/workflows/regenerate-model-docs.yml
@@ -27,7 +27,7 @@ jobs:
   regenerate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -50,7 +50,7 @@ jobs:
         run: python generate-model-docs.py --models-url "$MODELS_URL"
 
       - name: Open pull request if anything changed
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "Regenerate model API reference docs"
           title: "Regenerate model API reference docs"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,7 @@ still keep it separate from the command that produced it.
 ## Public
 
 This repository is **public**. Do not mention Oxen's private/internal repositories — by name or description — in code comments, doc-comments, error messages, commit messages, PR titles or descriptions, or any other code or documentation committed here. Keep references to private repos out of public artifacts entirely; if internal context is genuinely needed, point to the relevant Linear issue rather than inlining private-repo details.
+
+## GitHub Actions
+
+Pin actions in `.github/workflows/` by trust tier, following the org-wide policy: <https://github.com/Oxen-AI/Oxen/blob/main/docs/github_actions_pinning.md> — version tag for first-party/high-trust orgs, full commit SHA with a `# vX.Y.Z` comment for third-party.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,4 +80,4 @@ This repository is **public**. Do not mention Oxen's private/internal repositori
 
 ## GitHub Actions
 
-Pin actions in `.github/workflows/` by trust tier, following the org-wide policy: <https://github.com/Oxen-AI/Oxen/blob/main/docs/github_actions_pinning.md> — version tag for first-party/high-trust orgs, full commit SHA with a `# vX.Y.Z` comment for third-party.
+Pin actions in `.github/workflows/` by trust tier, following the [org-wide policy](https://github.com/Oxen-AI/Oxen/blob/main/docs/github_actions_pinning.md) — version tag for first-party/high-trust orgs, full commit SHA with a `# vX.Y.Z` comment for third-party.


### PR DESCRIPTION
Bumps this repo's GitHub Actions to their latest versions, and points this repo's `CLAUDE.md` at the org-wide Actions-pinning policy established in [Oxen-AI/Oxen#696](https://github.com/Oxen-AI/Oxen/pull/696) — version tag for first-party/high-trust orgs, full commit SHA with a `# vX.Y.Z` comment for third-party.

Updated actions:
- `actions/checkout`: v6 → v7
- `peter-evans/create-pull-request`: v6 → v8.1.1
