### PR TITLE
State that oxen-server is not supported on Windows

### DIFF
--- a/getting-started/install.mdx
+++ b/getting-started/install.mdx
@@ -200,11 +200,10 @@ mv oxen-server /usr/local/bin
 ```
 
 ### Windows
-We provide Windows binaries as a .exe.
 
-```bash
-wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-server-windows-x86_64.exe.zip
-```
+<Warning>
+  `oxen-server` is **not supported on Windows**. Host the server on Linux, macOS, or Docker (see the sections above). The Windows `oxen` CLI and the Python package still work as clients against a server running on a supported platform.
+</Warning>
 
 To get up and running using the client and server, you can follow the [getting started docs](https://github.com/Oxen-AI/oxen).
 

--- a/getting-started/oxen-server.mdx
+++ b/getting-started/oxen-server.mdx
@@ -17,6 +17,10 @@ The hosted solution comes with a [UI](https://oxen.ai) and the benefits of not h
 
 To setup a local Oxen Server instance, first install the `oxen-server` binary.
 
+<Note>
+  `oxen-server` is supported on **Linux, macOS, and Docker**. It is **not supported on Windows**. The `oxen` CLI and Python client *are* supported on Windows and can connect to a server hosted on a supported platform.
+</Note>
+
 
 ### Mac OS
 


### PR DESCRIPTION
The install and self-hosting docs no longer offer a Windows oxen-server binary and now say plainly that the server runs on Linux, macOS, or Docker. This removes a contradiction — the install page previously handed Windows users a server .exe we don't stand behind — and points them to the oxen CLI and Python client against a server hosted on a supported platform.

Tracked in ENG-1233.